### PR TITLE
Fix concurrency bugs, resource leaks, and refactor SearchModel

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,10 @@ func startApp() {
 		os.Exit(1)
 	}
 
+	m.SearchManager.Cancel()
+	m.FormatsManager.Cancel()
+	m.DownloadManager.Cancel()
+
 	saveConfigOptions(m)
 }
 

--- a/internal/models/formatAutocomplete.go
+++ b/internal/models/formatAutocomplete.go
@@ -265,7 +265,9 @@ func (m *FormatAutocompleteModel) View(width, height int) string {
 		}
 
 		if result.Format.FormatType != "" {
-			if !(strings.Contains(result.Format.Resolution, "audio") && strings.Contains(result.Format.FormatType, "audio")) {
+			res := strings.ToLower(result.Format.Resolution)
+			ft := strings.ToLower(result.Format.FormatType)
+			if !(strings.Contains(res, "audio") && strings.Contains(ft, "audio")) {
 				itemText += " - " + result.Format.FormatType
 			}
 		}

--- a/internal/models/formatAutocomplete.go
+++ b/internal/models/formatAutocomplete.go
@@ -265,8 +265,7 @@ func (m *FormatAutocompleteModel) View(width, height int) string {
 		}
 
 		if result.Format.FormatType != "" {
-			if strings.Contains(result.Format.Resolution, "audio") && strings.Contains(result.Format.FormatType, "audio") {
-			} else {
+			if !(strings.Contains(result.Format.Resolution, "audio") && strings.Contains(result.Format.FormatType, "audio")) {
 				itemText += " - " + result.Format.FormatType
 			}
 		}

--- a/internal/models/history.go
+++ b/internal/models/history.go
@@ -1,0 +1,71 @@
+package models
+
+import (
+	"log"
+
+	"github.com/xdagiz/xytz/internal/utils"
+)
+
+type HistoryNavigator struct {
+	items         []string
+	index         int
+	originalQuery string
+}
+
+func NewHistoryNavigator() HistoryNavigator {
+	h := HistoryNavigator{index: -1}
+	h.Load()
+	return h
+}
+
+func (h *HistoryNavigator) Load() {
+	history, err := utils.LoadHistory()
+	if err != nil {
+		log.Printf("Failed to load history: %v", err)
+		h.items = []string{}
+	} else {
+		h.items = history
+	}
+}
+
+func (h *HistoryNavigator) Add(query string) {
+	if err := utils.AddToHistory(query); err != nil {
+		log.Printf("Failed to save history: %v", err)
+	}
+	h.index = -1
+	h.originalQuery = ""
+	h.Load()
+}
+
+func (h *HistoryNavigator) Navigate(dir int, getCurrentValue func() string, setValue func(string)) {
+	if h.index == -1 {
+		h.originalQuery = getCurrentValue()
+	}
+
+	newIndex := h.index + dir
+
+	if newIndex < 0 {
+		h.index = -1
+		setValue(h.originalQuery)
+	} else if newIndex >= len(h.items) {
+		h.index = len(h.items) - 1
+	} else {
+		h.index = newIndex
+		setValue(h.items[newIndex])
+	}
+}
+
+func (h *HistoryNavigator) TrackEdit(oldValue, newValue string) {
+	if h.index >= 0 && h.index < len(h.items) {
+		expectedValue := h.items[h.index]
+		if oldValue != newValue && newValue != expectedValue {
+			h.index = -1
+			h.originalQuery = ""
+		}
+	}
+}
+
+func (h *HistoryNavigator) Reset() {
+	h.index = -1
+	h.originalQuery = ""
+}

--- a/internal/models/history.go
+++ b/internal/models/history.go
@@ -37,6 +37,8 @@ func (h *HistoryNavigator) Add(query string) {
 	h.Load()
 }
 
+// Navigate moves through history. dir=+1 goes to older entries, dir=-1 goes to newer.
+// When returning past the newest entry (index -1), the original query is restored.
 func (h *HistoryNavigator) Navigate(dir int, getCurrentValue func() string, setValue func(string)) {
 	if h.index == -1 {
 		h.originalQuery = getCurrentValue()

--- a/internal/models/resume.go
+++ b/internal/models/resume.go
@@ -1,11 +1,12 @@
 package models
 
 import (
+	"sort"
+
 	"github.com/xdagiz/xytz/internal/styles"
 	"github.com/xdagiz/xytz/internal/utils"
 
 	"github.com/charmbracelet/bubbles/list"
-	"github.com/charmbracelet/lipgloss"
 )
 
 type ResumeItem struct {
@@ -60,13 +61,9 @@ func (m *ResumeModel) LoadItems() {
 		return
 	}
 
-	for i := range items {
-		for j := i + 1; j < len(items); j++ {
-			if items[i].Timestamp.Before(items[j].Timestamp) {
-				items[i], items[j] = items[j], items[i]
-			}
-		}
-	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Timestamp.After(items[j].Timestamp)
+	})
 
 	listItems := make([]list.Item, len(items))
 	for i, item := range items {
@@ -117,12 +114,5 @@ func (m *ResumeModel) View(width, height int) string {
 		headerText = "Resume Downloads"
 	}
 
-	var s lipgloss.Style
-	if m.List.FilterState() == list.Filtering || m.List.FilterState() == list.FilterApplied {
-		s = styles.SectionHeaderStyle
-	} else {
-		s = styles.SectionHeaderStyle
-	}
-
-	return s.Render(headerText) + "\n" + styles.ListContainer.Render(m.List.View())
+	return styles.SectionHeaderStyle.Render(headerText) + "\n" + styles.ListContainer.Render(m.List.View())
 }

--- a/internal/slash/commands.go
+++ b/internal/slash/commands.go
@@ -46,6 +46,24 @@ type MatchResult struct {
 	Matched bool
 }
 
+func ParseCommand(input string) (cmd string, args string, isSlash bool) {
+	input = strings.TrimSpace(input)
+	if !strings.HasPrefix(input, "/") {
+		return "", "", false
+	}
+
+	rest := strings.TrimPrefix(input, "/")
+
+	spaceIdx := strings.Index(rest, " ")
+	if spaceIdx == -1 {
+		return rest, "", true
+	}
+
+	cmd = rest[:spaceIdx]
+	args = strings.TrimSpace(rest[spaceIdx:])
+	return cmd, args, true
+}
+
 func FuzzyMatch(query string) []MatchResult {
 	query = strings.TrimPrefix(query, "/")
 

--- a/internal/utils/browser.go
+++ b/internal/utils/browser.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"log"
+	"os/exec"
+	"runtime"
+)
+
+func OpenURL(url string) {
+	go func() {
+		var cmd *exec.Cmd
+		switch runtime.GOOS {
+		case "windows":
+			cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+		case "darwin":
+			cmd = exec.Command("open", url)
+		default:
+			cmd = exec.Command("xdg-open", url)
+		}
+
+		if err := cmd.Start(); err != nil {
+			log.Printf("Failed to open URL: %v", err)
+		}
+	}()
+}

--- a/internal/utils/browser.go
+++ b/internal/utils/browser.go
@@ -20,6 +20,10 @@ func OpenURL(url string) {
 
 		if err := cmd.Start(); err != nil {
 			log.Printf("Failed to open URL: %v", err)
+			return
+		}
+		if err := cmd.Wait(); err != nil {
+			log.Printf("Failed to open URL: %v", err)
 		}
 	}()
 }

--- a/internal/utils/download.go
+++ b/internal/utils/download.go
@@ -159,6 +159,7 @@ func doDownload(dm *DownloadManager, program *tea.Program, url, formatID string,
 
 	stderr, err2 := cmd.StderrPipe()
 	if err2 != nil {
+		stdout.Close()
 		log.Printf("stderr pipe error: %v", err2)
 		errMsg := fmt.Sprintf("stderr pipe error: %v", err2)
 		program.Send(types.DownloadResultMsg{Err: errMsg})
@@ -166,6 +167,8 @@ func doDownload(dm *DownloadManager, program *tea.Program, url, formatID string,
 	}
 
 	if err := cmd.Start(); err != nil {
+		stdout.Close()
+		stderr.Close()
 		log.Printf("start error: %v", err)
 		errMsg := fmt.Sprintf("start error: %v", err)
 		program.Send(types.DownloadResultMsg{Err: errMsg})

--- a/internal/utils/download.go
+++ b/internal/utils/download.go
@@ -178,13 +178,13 @@ func doDownload(dm *DownloadManager, program *tea.Program, url, formatID string,
 	parser := NewProgressParser()
 	var wg sync.WaitGroup
 	readPipe := func(pipe io.Reader) {
-		wg.Add(1)
 		defer wg.Done()
 		parser.ReadPipe(pipe, func(percent float64, speed, eta, status, destination string) {
 			program.Send(types.ProgressMsg{Percent: percent, Speed: speed, Eta: eta, Status: status, Destination: destination, FileExtension: fileExtension})
 		})
 	}
 
+	wg.Add(2)
 	go readPipe(stdout)
 	go readPipe(stderr)
 	wg.Wait()

--- a/internal/utils/formats.go
+++ b/internal/utils/formats.go
@@ -129,14 +129,11 @@ func FetchFormats(fm *FormatsManager, url string) tea.Cmd {
 		}
 
 		out, err := io.ReadAll(stdout)
-		if err := stdout.Close(); err != nil {
-			log.Printf("failed to close formats stdout: %v", err)
+		if closeErr := stdout.Close(); closeErr != nil {
+			log.Printf("failed to close formats stdout: %v", closeErr)
 		}
 
-		wasCancelled := fm.WasCanceled()
-		fm.Clear()
-
-		if wasCancelled {
+		if fm.ClearAndCheckCanceled() {
 			return nil
 		}
 

--- a/internal/utils/formats_manager.go
+++ b/internal/utils/formats_manager.go
@@ -52,6 +52,16 @@ func (fm *FormatsManager) Clear() {
 	fm.canceled = false
 }
 
+func (fm *FormatsManager) ClearAndCheckCanceled() bool {
+	fm.mutex.Lock()
+	defer fm.mutex.Unlock()
+
+	wasCanceled := fm.canceled
+	fm.cmd = nil
+	fm.canceled = false
+	return wasCanceled
+}
+
 func (fm *FormatsManager) Cancel() error {
 	fm.mutex.Lock()
 	defer fm.mutex.Unlock()

--- a/internal/utils/search_manager.go
+++ b/internal/utils/search_manager.go
@@ -52,6 +52,16 @@ func (sm *SearchManager) Clear() {
 	sm.canceled = false
 }
 
+func (sm *SearchManager) ClearAndCheckCanceled() bool {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	wasCanceled := sm.canceled
+	sm.cmd = nil
+	sm.canceled = false
+	return wasCanceled
+}
+
 func (sm *SearchManager) Cancel() error {
 	sm.mutex.Lock()
 	defer sm.mutex.Unlock()


### PR DESCRIPTION
## Summary

- **Graceful shutdown**: Cancel all active yt-dlp child processes when the app exits, preventing orphaned processes
- **Data race fix**: Add `sync.WaitGroup` around stderr goroutine in search to prevent concurrent read/write on `stderrLines`
- **TOCTOU race fix**: Add atomic `ClearAndCheckCanceled()` to `SearchManager` and `FormatsManager`, replacing separate `WasCanceled()`/`Clear()` calls
- **Resource leak fix**: Close stdout/stderr pipes in `download.go` error paths when `StderrPipe()` or `cmd.Start()` fails
- **Shadowed error fix**: Rename inner `err` to `closeErr` in `formats.go` to avoid confusing variable shadowing
- **Performance**: Replace O(n²) bubble sort with `sort.Slice` in resume model
- **Dead code removal**: Remove identical if/else branches in resume view, unused `lipgloss` import
- **Code smell**: Invert empty if-block in format autocomplete
- **SearchModel refactor**: Extract `HistoryNavigator` struct, move `openGithub()` to `utils.OpenURL()`, move `parseSlashCommand()` to `slash.ParseCommand()`, break up 191-line `Update()` into focused helpers (`handleHelpInput`, `handleResumeEsc`, `handleEnterKey`)

## Files changed

| File | Changes |
|------|---------|
| `cmd/root.go` | Graceful shutdown cleanup |
| `internal/utils/search.go` | stderr WaitGroup, atomic cancel check |
| `internal/utils/search_manager.go` | `ClearAndCheckCanceled()` |
| `internal/utils/formats.go` | Shadowed error, atomic cancel check |
| `internal/utils/formats_manager.go` | `ClearAndCheckCanceled()` |
| `internal/utils/download.go` | Pipe leak fix |
| `internal/utils/browser.go` | **New** — extracted `OpenURL()` |
| `internal/models/resume.go` | `sort.Slice`, dead code removal |
| `internal/models/formatAutocomplete.go` | Empty if-block inversion |
| `internal/models/search.go` | Refactored (539→~370 lines) |
| `internal/models/history.go` | **New** — extracted `HistoryNavigator` |
| `internal/slash/commands.go` | Added `ParseCommand()` |

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Search → pick format → download → Ctrl+C mid-download (graceful shutdown)
- [ ] `/help`, `/resume`, `/channel`, `/playlist` slash commands work
- [ ] History up/down navigation works
- [ ] Autocomplete works
- [ ] Resume list filtering works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced history navigation with edit tracking.
  * Improved slash-command parsing and external link opening.

* **Bug Fixes**
  * More reliable cleanup on exit and during downloads.
  * Better synchronization for command output capture.

* **Refactor**
  * Simplified and unified history management and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->