### PR TITLE
fix(thumbnail): use raw output for other protocols to work

### DIFF
--- a/internal/tui/thumbnail.go
+++ b/internal/tui/thumbnail.go
@@ -1,6 +1,9 @@
 package tui
 
 import (
+	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/blacktop/go-termimg"
@@ -73,10 +76,15 @@ func (m *Model) configureThumbnailWidget(w *termimg.ImageWidget) {
 		return
 	}
 
-	availableWidth := m.Width / 2
-	width := availableWidth + 40
-	height := (width * 9) / 32
+	paneWidth := m.thumbnailPaneWidth()
+	if paneWidth < 10 {
+		return
+	}
 
+	width := max(paneWidth-4, 8)
+	height := max((width*9)/32, 2)
+
+	m.ThumbnailImageHeight = height
 	w.SetSize(width, height)
 }
 
@@ -116,6 +124,26 @@ func (m *Model) fetchThumbnailCmd(video types.VideoItem) tea.Cmd {
 
 func (m *Model) clearThumbnailForStateTransition() {
 	m.cancelThumbnailWork()
+	if m.State == types.StateVideoList && m.isGraphicProtocol() && m.ThumbnailRendered != "" {
+		features := termimg.QueryTerminalFeatures()
+		if features.KittyGraphics {
+			_ = termimg.ClearAll()
+		}
+
+		if features.SixelGraphics && m.ThumbnailImageHeight > 0 {
+			buf := strings.Builder{}
+
+			fmt.Fprintf(&buf, "\x1b[%d;0H", 3)
+			for i := range m.ThumbnailImageHeight {
+				buf.WriteString("\x1b[2K")
+				if i < m.ThumbnailImageHeight-1 {
+					buf.WriteString("\x1b[B")
+				}
+			}
+
+			os.Stdout.Write([]byte(buf.String()))
+		}
+	}
 	m.resetThumbnailState()
 }
 
@@ -125,6 +153,15 @@ func (m *Model) thumbnailPaneWidth() int {
 	}
 
 	return m.Width / 2
+}
+
+func (m *Model) isGraphicProtocol() bool {
+	if m.ThumbnailWidget == nil {
+		return false
+	}
+
+	features := termimg.QueryTerminalFeatures()
+	return features.KittyGraphics || features.SixelGraphics || features.ITerm2Graphics
 }
 
 func (m *Model) videoListPaneWidth() int {

--- a/internal/tui/thumbnail.go
+++ b/internal/tui/thumbnail.go
@@ -162,7 +162,10 @@ func (m *Model) isGraphicProtocol() bool {
 	if m.ThumbnailWidget == nil {
 		return false
 	}
+	return m.supportsGraphicProtocol()
+}
 
+func (m *Model) supportsGraphicProtocol() bool {
 	if m.TerminalFeatures == nil {
 		m.TerminalFeatures = termimg.QueryTerminalFeatures()
 	}

--- a/internal/tui/thumbnail.go
+++ b/internal/tui/thumbnail.go
@@ -141,7 +141,7 @@ func (m *Model) clearThumbnailForStateTransition() {
 				}
 			}
 
-			os.Stdout.Write([]byte(buf.String()))
+			_, _ = os.Stdout.Write([]byte(buf.String()))
 		}
 	}
 	m.resetThumbnailState()

--- a/internal/tui/thumbnail.go
+++ b/internal/tui/thumbnail.go
@@ -11,6 +11,7 @@ import (
 	"github.com/xdagiz/xytz/internal/utils"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/log/v2"
 )
 
 type thumbnailDebounceMsg struct {
@@ -133,15 +134,17 @@ func (m *Model) clearThumbnailForStateTransition() {
 		if features.SixelGraphics && m.ThumbnailImageHeight > 0 {
 			buf := strings.Builder{}
 
-			fmt.Fprintf(&buf, "\x1b[%d;0H", 3)
-			for i := range m.ThumbnailImageHeight {
+			fmt.Fprintf(&buf, "\x1b[%d;0H", m.thumbnailRow())
+			for i := 0; i < m.ThumbnailImageHeight; i++ {
 				buf.WriteString("\x1b[2K")
 				if i < m.ThumbnailImageHeight-1 {
 					buf.WriteString("\x1b[B")
 				}
 			}
 
-			_, _ = os.Stdout.Write([]byte(buf.String()))
+			if _, err := os.Stdout.Write([]byte(buf.String())); err != nil {
+				log.Warn("failed to write image to stdout", "err", err)
+			}
 		}
 	}
 	m.resetThumbnailState()
@@ -160,8 +163,13 @@ func (m *Model) isGraphicProtocol() bool {
 		return false
 	}
 
-	features := termimg.QueryTerminalFeatures()
-	return features.KittyGraphics || features.SixelGraphics || features.ITerm2Graphics
+	if m.TerminalFeatures == nil {
+		m.TerminalFeatures = termimg.QueryTerminalFeatures()
+	}
+
+	return m.TerminalFeatures.KittyGraphics ||
+		m.TerminalFeatures.SixelGraphics ||
+		m.TerminalFeatures.ITerm2Graphics
 }
 
 func (m *Model) videoListPaneWidth() int {
@@ -170,4 +178,8 @@ func (m *Model) videoListPaneWidth() int {
 	}
 
 	return m.Width / 2
+}
+
+func (m *Model) thumbnailRow() int {
+	return 3
 }

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -25,38 +25,39 @@ import (
 )
 
 type Model struct {
-	Program           *tea.Program
-	Ctx               *ctx.AppContext
-	Search            search.Model
-	videolist         videolist.Model
-	channellist       channellist.Model
-	playlistlist      playlistlist.Model
-	formatlist        formatlist.Model
-	download          download.Model
-	player            player.Model
-	playlistOpts      playlistopts.Model
-	Spinner           spinner.Model
-	State             types.State
-	playbackOrigin    types.State
-	downloadOrigin    types.State
-	Width             int
-	Height            int
-	LoadingType       string
-	CurrentQuery      string
-	CurrentSiteName   string
-	Videos            []list.Item
-	SelectedVideo     types.VideoItem
-	ErrMsg            string
-	ToastMsg          string
-	ToastSeq          int
-	ThumbnailWidget   *termimg.ImageWidget
-	ThumbnailVideoID  string
-	ThumbnailURL      string
-	ThumbnailErr      string
-	ThumbnailRendered string
-	ThumbnailLoading  bool
-	ThumbnailSeq      int
-	ThumbnailEnabled  bool
+	Program              *tea.Program
+	Ctx                  *ctx.AppContext
+	Search               search.Model
+	videolist            videolist.Model
+	channellist          channellist.Model
+	playlistlist         playlistlist.Model
+	formatlist           formatlist.Model
+	download             download.Model
+	player               player.Model
+	playlistOpts         playlistopts.Model
+	Spinner              spinner.Model
+	State                types.State
+	playbackOrigin       types.State
+	downloadOrigin       types.State
+	Width                int
+	Height               int
+	LoadingType          string
+	CurrentQuery         string
+	CurrentSiteName      string
+	Videos               []list.Item
+	SelectedVideo        types.VideoItem
+	ErrMsg               string
+	ToastMsg             string
+	ToastSeq             int
+	ThumbnailWidget      *termimg.ImageWidget
+	ThumbnailVideoID     string
+	ThumbnailURL         string
+	ThumbnailErr         string
+	ThumbnailRendered    string
+	ThumbnailLoading     bool
+	ThumbnailSeq         int
+	ThumbnailEnabled     bool
+	ThumbnailImageHeight int
 }
 
 type ModelOption func(*Model)
@@ -121,6 +122,9 @@ func NewModel(opts ...ModelOption) *Model {
 	}
 
 	model.configureThumbnailDefaults()
+
+	termimg.QueryTerminalFeatures()
+
 	return model
 }
 
@@ -279,7 +283,10 @@ func (m *Model) configureThumbnailDefaults() {
 	cfg := m.runtimeConfig()
 	m.ThumbnailEnabled = cfg.ThumbnailPreview
 
-	_ = os.Setenv("TERMIMG_BYPASS_DETECTION", "halfblocks")
+	termName := strings.ToLower(os.Getenv("TERM"))
+	if strings.Contains(termName, "alacritty") {
+		_ = os.Setenv("TERMIMG_BYPASS_DETECTION", "halfblocks")
+	}
 }
 
 func (m *Model) runtimeConfig() *config.Config {

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -50,6 +50,7 @@ type Model struct {
 	ToastMsg             string
 	ToastSeq             int
 	ThumbnailWidget      *termimg.ImageWidget
+	TerminalFeatures     *termimg.TerminalFeatures
 	ThumbnailVideoID     string
 	ThumbnailURL         string
 	ThumbnailErr         string
@@ -122,8 +123,7 @@ func NewModel(opts ...ModelOption) *Model {
 	}
 
 	model.configureThumbnailDefaults()
-
-	termimg.QueryTerminalFeatures()
+	model.TerminalFeatures = termimg.QueryTerminalFeatures()
 
 	return model
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1174,6 +1174,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, cmd
 
+	case tea.RawMsg:
+		return m, nil
+
 	case thumbnailDebounceMsg:
 		if !m.ThumbnailEnabled || msg.Seq != m.ThumbnailSeq {
 			return m, nil
@@ -1215,6 +1218,22 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.ThumbnailRendered = msg.Rendered
+		if m.isGraphicProtocol() && m.ThumbnailRendered != "" {
+			rendered := m.ThumbnailRendered
+			col := m.videoListPaneWidth() + 2
+			row := 3
+
+			return m, func() tea.Msg {
+				buf := strings.Builder{}
+				buf.WriteString("\x1b[s")
+
+				fmt.Fprintf(&buf, "\x1b[%d;%dH", row, col)
+				buf.WriteString(rendered)
+				buf.WriteString("\x1b[u")
+
+				return tea.RawMsg{Msg: buf.String()}
+			}
+		}
 		return m, nil
 
 	case tea.PasteMsg:

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -70,6 +70,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.configureThumbnailWidget(m.ThumbnailWidget)
 			cmd = tea.Batch(cmd, m.refreshThumbnailRenderAsync())
 		}
+		if m.isGraphicProtocol() || (msg.Width >= 100 && m.ThumbnailEnabled && m.supportsGraphicProtocol()) {
+			if msg.Width < 100 {
+				m.clearThumbnailForStateTransition()
+			} else if m.ThumbnailEnabled && msg.Width >= 100 {
+				if video, ok := m.videolist.SelectedVideo(); ok {
+					cmd = tea.Batch(cmd, m.queueThumbnailFetch(video))
+				}
+			}
+		}
 		return m, cmd
 
 	case spinner.TickMsg:
@@ -1225,7 +1234,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if row > m.Height {
 				row = m.Height
 			}
-
 			return m, func() tea.Msg {
 				buf := strings.Builder{}
 				buf.WriteString("\x1b[s")

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1174,9 +1174,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, cmd
 
-	case tea.RawMsg:
-		return m, nil
-
 	case thumbnailDebounceMsg:
 		if !m.ThumbnailEnabled || msg.Seq != m.ThumbnailSeq {
 			return m, nil
@@ -1221,9 +1218,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.isGraphicProtocol() && m.ThumbnailRendered != "" {
 			rendered := m.ThumbnailRendered
 			col := m.videoListPaneWidth() + 2
-			row := 3
-
-			// Validate bounds against terminal dimensions
+			row := m.thumbnailRow()
 			if col > m.Width {
 				col = m.Width
 			}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -1223,6 +1223,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			col := m.videoListPaneWidth() + 2
 			row := 3
 
+			// Validate bounds against terminal dimensions
+			if col > m.Width {
+				col = m.Width
+			}
+			if row > m.Height {
+				row = m.Height
+			}
+
 			return m, func() tea.Msg {
 				buf := strings.Builder{}
 				buf.WriteString("\x1b[s")

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -278,9 +278,11 @@ func (m *Model) videoListWithThumbnailView() string {
 	}
 
 	left := m.videolist.View()
-	right := m.thumbnailPaneView()
+	if m.isGraphicProtocol() {
+		return left
+	}
 
-	return lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, m.thumbnailPaneView())
 }
 
 func (m *Model) thumbnailPaneView() string {


### PR DESCRIPTION
fixes #34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal thumbnail graphics for Kitty, Sixel, and iTerm2 with more accurate sizing and rendering.
* **UI Updates**
  * Thumbnail pane layout now adapts to graphic-protocol support (hidden when supported) and to terminal resize width.
  * Thumbnail rendering now uses direct terminal positioning to ensure consistent placement.
* **Bug Fixes**
  * Improved thumbnail clearing during state transitions, including protocol-specific erase behavior.
  * Prevented thumbnail raw terminal output from disrupting normal update flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->