### PR TITLE
Update vendorHash for xytz package in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
             pname = "xytz";
             version = "unstable";
             src = pkgs.lib.cleanSource ./.;
-            vendorHash = "sha256-j4K61ESqtlfOD8S3E0vtL18aziSFztoU3V0KSLtJEME=";
+            vendorHash = "sha256-vCJJ0aBSBANk2eVn7Vq7hPz0V32s7xmeIfSg0jy/Dzk=";
             doCheck = false;
             nativeBuildInputs = [ pkgs.makeWrapper ];
             postInstall = ''


### PR DESCRIPTION
**Mismatch Hash with the upstream build**
The build currently fails because the vendorHash for the xytz-unstable Go modules no longer matches the downloaded dependencies.

Build logs:
```bash
building the system configuration...
error: hash mismatch in fixed-output derivation '/nix/store/bj6byxs1simvlrvjvdms6g0z2hgqg2ab-xytz-unstable-go-modules.drv':
         specified: sha256-j4K61ESqtlfOD8S3E0vtL18aziSFztoU3V0KSLtJEME=
            got:    sha256-vCJJ0aBSBANk2eVn7Vq7hPz0V32s7xmeIfSg0jy/Dzk=
error: Cannot build '/nix/store/7ik1pldxxq6mjm0v99h5z5r7l201j5ms-xytz-unstable.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/f1v66k248ipiix6zdryps22zg9p8gvxw-xytz-unstable
error: Build failed due to failed dependency
error: Cannot build '/nix/store/kx43jxgqrxf94nz95snx0da4qwnakq8m-home-manager-path.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/dsknxp1mbq3kxs9klga8bgbillv77m74-home-manager-path
error: Build failed due to failed dependency
error: Cannot build '/nix/store/8s2syl2q10s1nwrxk1934k036ldc4ln2-hm_hmfontconfigfonts.xml.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/lf2icf527w3wfjy5jf4m400d6j8pabi9-hm_hmfontconfigfonts.xml
error: Cannot build '/nix/store/94hnc0vwq77x7yq5jb6571dggdcfgygl-home-manager-generation.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/2a6wvwr8mw47sl4n8zaw1gc8w0036d20-home-manager-generation
error: Cannot build '/nix/store/qmp208f1ilgs97y8nkqdlcsj5ky5cnz1-user-environment.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/5ndcxw8s5vi21whm8cj4qbj3m8fcy6rn-user-environment
error: Build failed due to failed dependency
error: Build failed due to failed dependency
error: Cannot build '/nix/store/n8rihf4ynn83yc4ixsq9c6yyy5wg9igl-etc.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/x7ifxma6ds1bg7v91kxiv41wgq3nn88k-etc
error: Cannot build '/nix/store/9c91xy4i9mz68b4wvjj8vsx6z97r2299-unit-home-manager-username.service.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/8alxg75avnk4k80azrzglffgbf8zrm00-unit-home-manager-username.service
error: Build failed due to failed dependency
error: Cannot build '/nix/store/r4pqdks4lyifcc23kspx14msa084g4y0-activate.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/s4kwxx0z54prs03kphp4jbq54p551bc4-activate
error: Cannot build '/nix/store/75rqjnwx0kv0nyfa1qya7vgnrqn7qcs7-nixos-system-hostname-26.11.20260616.567a49d.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/6agb446mkrd3smb2ag5p0cri0zyncmzg-nixos-system-hosname-26.11.20260616.567a49d
error: Build failed due to failed dependency
Command 'nix --extra-experimental-features 'nix-command flakes' build --print-out-paths '.#nixosConfigurations."hostname".config.system.build.toplevel' --no-link' returned non-zero exit status 1.
```

# Changes:
Updated the vendorHash to match the current Go module dependencies.
as reported by Nix
```yaml
- specified:  sha256-j4K61ESqtlfOD8S3E0vtL18aziSFztoU3V0KSLtJEME=
+       got:  sha256-vCJJ0aBSBANk2eVn7Vq7hPz0V32s7xmeIfSg0jy/Dzk=
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for the Go package to match the current dependency lock, with no user-facing feature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->