### PR TITLE
feat(tui): keep playback running while browsing

### DIFF
--- a/internal/tui/models/keys.go
+++ b/internal/tui/models/keys.go
@@ -5,9 +5,10 @@ import (
 )
 
 type globalKeys struct {
-	TabNext key.Binding
-	TabPrev key.Binding
-	CopyURL key.Binding
+	TabNext    key.Binding
+	TabPrev    key.Binding
+	CopyURL    key.Binding
+	NowPlaying key.Binding
 }
 
 var GlobalModelKeys = globalKeys{
@@ -22,6 +23,10 @@ var GlobalModelKeys = globalKeys{
 	CopyURL: key.NewBinding(
 		key.WithKeys("ctrl+y"),
 		key.WithHelp("ctrl+y", "copy url"),
+	),
+	NowPlaying: key.NewBinding(
+		key.WithKeys("n"),
+		key.WithHelp("n", "now playing"),
 	),
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -862,13 +862,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		if msg.IsPlayerExit {
-			var target types.State = types.StateSearchInput
-			if m.playbackOrigin == types.StateVideoList {
-				target = types.StateVideoList
+			if m.State == types.StateVideoPlaying {
+				m.transitionTo(m.playbackBackTarget())
 			}
+
 			m.player = player.Model{}
 			m.playbackOrigin = ""
-			m.transitionTo(target)
 			return m, nil
 		}
 
@@ -930,6 +929,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.Ctx.PlayerManager.Kill()
 			}
 			return m, tea.Quit
+		case "n":
+			if canShowNowPlayingKey(m.State) && m.player.Video.ID != "" {
+				m.playbackOrigin = m.State
+				m.transitionTo(types.StateVideoPlaying)
+				return m, nil
+			}
 		}
 
 		switch m.State {
@@ -1061,16 +1066,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case types.StateVideoPlaying:
 			switch msg.String() {
 			case "b", "esc":
-				var target types.State = types.StateSearchInput
-				if m.playbackOrigin == types.StateVideoList {
-					target = types.StateVideoList
-				}
-				if m.Ctx != nil && m.Ctx.PlayerManager != nil {
-					m.Ctx.PlayerManager.Kill()
-				}
-				m.player = player.Model{}
-				m.playbackOrigin = ""
-				m.transitionTo(target)
+				m.transitionTo(m.playbackBackTarget())
 				return m, nil
 			}
 		}
@@ -1175,6 +1171,38 @@ func (m *Model) transitionTo(newState types.State) {
 	m.LoadingType = ""
 }
 
+func canShowNowPlayingKey(state types.State) bool {
+	switch state {
+	case types.StateVideoList,
+		types.StateFormatList,
+		types.StateChannelList,
+		types.StatePlaylistList,
+		types.StateResumeList,
+		types.StateLaterList,
+		types.StatePlaylistOpts,
+		types.StateDownload:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Model) playbackBackTarget() types.State {
+	switch m.playbackOrigin {
+	case types.StateVideoList,
+		types.StateFormatList,
+		types.StateChannelList,
+		types.StatePlaylistList,
+		types.StateResumeList,
+		types.StateLaterList,
+		types.StatePlaylistOpts,
+		types.StateDownload:
+		return m.playbackOrigin
+	default:
+		return types.StateSearchInput
+	}
+}
+
 func (m *Model) setupAndStartQueue(videos []types.VideoItem, formatID string, isAudioTab bool, abr float64, queueLabel string) (tea.Model, tea.Cmd) {
 	if m.Ctx == nil || m.Ctx.DownloadManager == nil || m.Ctx.Config == nil {
 		m.ErrMsg = "Download manager not available"
@@ -1259,15 +1287,7 @@ func (m *Model) handleGoBack(from types.State, to types.State) tea.Cmd {
 			m.formatlist.List.ResetSelected()
 
 		case types.StateVideoPlaying:
-			if m.Ctx != nil && m.Ctx.PlayerManager != nil {
-				m.Ctx.PlayerManager.Kill()
-			}
-			if from == types.StateVideoList {
-				m.State = types.StateVideoList
-			} else {
-				m.State = types.StateSearchInput
-			}
-			m.player = player.Model{}
+			m.State = m.playbackBackTarget()
 			m.ErrMsg = ""
 		}
 

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -564,7 +564,7 @@ func TestModelUpdateStartResumeDownloadFallbacksToTitleAndURL(t *testing.T) {
 	}
 }
 
-func TestPlaybackOriginFromSearchInputGoBackToSearchInput(t *testing.T) {
+func TestPlaybackOriginFromSearchInputGoBackKeepsPlaybackState(t *testing.T) {
 	m := NewModel()
 	m.Width = 120
 	m.Height = 40
@@ -583,12 +583,16 @@ func TestPlaybackOriginFromSearchInputGoBackToSearchInput(t *testing.T) {
 		t.Fatalf("m.State = %q, want %q", m.State, types.StateSearchInput)
 	}
 
-	if m.playbackOrigin != "" {
-		t.Fatalf("m.playbackOrigin = %q, want empty string", m.playbackOrigin)
+	if m.playbackOrigin != types.StateSearchInput {
+		t.Fatalf("m.playbackOrigin = %q, want %q", m.playbackOrigin, types.StateSearchInput)
+	}
+
+	if m.player.Video.ID != "test-video-id" {
+		t.Fatalf("m.player.Video.ID = %q, want playback metadata retained", m.player.Video.ID)
 	}
 }
 
-func TestPlaybackOriginFromVideoListGoBackToVideoList(t *testing.T) {
+func TestPlaybackOriginFromVideoListGoBackKeepsPlaybackState(t *testing.T) {
 	m := NewModel()
 	m.Width = 120
 	m.Height = 40
@@ -608,12 +612,16 @@ func TestPlaybackOriginFromVideoListGoBackToVideoList(t *testing.T) {
 		t.Fatalf("m.State = %q, want %q", m.State, types.StateVideoList)
 	}
 
-	if m.playbackOrigin != "" {
-		t.Fatalf("m.playbackOrigin = %q, want empty string", m.playbackOrigin)
+	if m.playbackOrigin != types.StateVideoList {
+		t.Fatalf("m.playbackOrigin = %q, want %q", m.playbackOrigin, types.StateVideoList)
 	}
 
 	if m.SelectedVideo.ID != "test-video-id" {
 		t.Fatalf("m.SelectedVideo.ID = %q, want %q", m.SelectedVideo.ID, "test-video-id")
+	}
+
+	if m.player.Video.ID != "test-video-id" {
+		t.Fatalf("m.player.Video.ID = %q, want playback metadata retained", m.player.Video.ID)
 	}
 }
 
@@ -679,6 +687,77 @@ func TestPlaybackOriginBackKeyGoesToCorrectState(t *testing.T) {
 	}
 	if m.downloadOrigin != "" {
 		t.Fatalf("downloadOrigin = %q, want empty after go-back", m.downloadOrigin)
+	}
+}
+
+func TestPlayerExitWhileBrowsingDoesNotChangeState(t *testing.T) {
+	m := NewModel()
+	m.Width = 120
+	m.Height = 40
+	m.State = types.StateSearchInput
+
+	video := makeVideo("test-video-id", "Test Video")
+	m.player.Video = video
+	m.player.URL = "https://www.youtube.com/watch?v=test-video-id"
+	m.playbackOrigin = types.StateVideoList
+
+	updated, _ := m.Update(types.PlayVideoMsg{SelectedVideo: video, IsPlayerExit: true})
+	m = updated.(*Model)
+
+	if m.State != types.StateSearchInput {
+		t.Fatalf("m.State = %q, want %q", m.State, types.StateSearchInput)
+	}
+	if m.playbackOrigin != "" {
+		t.Fatalf("m.playbackOrigin = %q, want empty string", m.playbackOrigin)
+	}
+	if m.player.Video.ID != "" {
+		t.Fatalf("m.player.Video.ID = %q, want playback metadata cleared", m.player.Video.ID)
+	}
+}
+
+func TestNowPlayingKeyShowsPlayerAndReturnsToCurrentState(t *testing.T) {
+	m := NewModel()
+	m.Width = 120
+	m.Height = 40
+	m.State = types.StateFormatList
+
+	video := makeVideo("test-video-id", "Test Video")
+	m.player.Video = video
+	m.player.URL = "https://www.youtube.com/watch?v=test-video-id"
+	m.playbackOrigin = types.StateVideoList
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'n'})
+	m = updated.(*Model)
+
+	if m.State != types.StateVideoPlaying {
+		t.Fatalf("m.State = %q, want %q", m.State, types.StateVideoPlaying)
+	}
+	if m.playbackOrigin != types.StateFormatList {
+		t.Fatalf("m.playbackOrigin = %q, want %q", m.playbackOrigin, types.StateFormatList)
+	}
+
+	updated, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEsc})
+	m = updated.(*Model)
+
+	if m.State != types.StateFormatList {
+		t.Fatalf("m.State = %q, want %q", m.State, types.StateFormatList)
+	}
+	if m.player.Video.ID != "test-video-id" {
+		t.Fatalf("m.player.Video.ID = %q, want playback metadata retained", m.player.Video.ID)
+	}
+}
+
+func TestNowPlayingKeyIgnoredWithoutPlayback(t *testing.T) {
+	m := NewModel()
+	m.Width = 120
+	m.Height = 40
+	m.State = types.StateVideoList
+
+	updated, _ := m.Update(tea.KeyPressMsg{Code: 'n'})
+	m = updated.(*Model)
+
+	if m.State != types.StateVideoList {
+		t.Fatalf("m.State = %q, want %q", m.State, types.StateVideoList)
 	}
 }
 

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -43,6 +43,12 @@ func getStatusBarText(m *Model, cfg StatusBarConfig) string {
 	}
 
 	keys := GetStatusKeys(m.State)
+	withNowPlaying := func(bindings []key.Binding) []key.Binding {
+		if m != nil && canShowNowPlayingKey(m.State) && m.player.Video.ID != "" {
+			return append(bindings, binding(keys.NowPlaying))
+		}
+		return bindings
+	}
 
 	switch m.State {
 	case types.StateSearchInput:
@@ -50,39 +56,39 @@ func getStatusBarText(m *Model, cfg StatusBarConfig) string {
 			return renderHelp(SearchHelpStatusKeys(m.Search.Help.Keys))
 		}
 
-		return renderHelp([]key.Binding{
+		return renderHelp(withNowPlaying([]key.Binding{
 			binding(keys.Quit),
 			binding(keys.StarOnGithub),
 			binding(keys.Up),
 			binding(keys.Down),
-		})
+		}))
 
 	case types.StateResumeList, types.StateLaterList:
-		return renderHelp([]key.Binding{
+		return renderHelp(withNowPlaying([]key.Binding{
 			binding(keys.Select),
 			binding(keys.Delete),
 			binding(keys.Cancel),
-		})
+		}))
 
 	case types.StateLoading:
 		return renderHelp(LoadingStatusKeys(keys))
 
 	case types.StateVideoList:
 		if cfg.HasError {
-			return renderHelp([]key.Binding{
+			return renderHelp(withNowPlaying([]key.Binding{
 				binding(keys.Quit),
 				binding(keys.Enter),
-			})
+			}))
 		}
 		if cfg.SelectedVideosCount > 0 {
 			return fmt.Sprintf("Selected: %d videos • %s", cfg.SelectedVideosCount,
-				renderHelp([]key.Binding{
+				renderHelp(withNowPlaying([]key.Binding{
 					binding(keys.Quit),
 					binding(keys.DownloadDefault),
 					binding(keys.Back),
-				}))
+				})))
 		}
-		return renderHelp([]key.Binding{
+		return renderHelp(withNowPlaying([]key.Binding{
 			binding(keys.Quit),
 			binding(keys.Back),
 			binding(keys.PlayVideo),
@@ -93,38 +99,38 @@ func getStatusBarText(m *Model, cfg StatusBarConfig) string {
 			binding(keys.GotoUploader),
 			binding(keys.CopyURL),
 			binding(keys.Save),
-		})
+		}))
 
 	case types.StateFormatList:
-		return renderHelp([]key.Binding{
+		return renderHelp(withNowPlaying([]key.Binding{
 			binding(keys.Quit),
 			binding(keys.Back),
 			binding(keys.Tab),
 			binding(keys.CopyURL),
 			binding(keys.Save),
-		})
+		}))
 
 	case types.StateChannelList:
-		return renderHelp([]key.Binding{
+		return renderHelp(withNowPlaying([]key.Binding{
 			binding(keys.Quit),
 			binding(keys.Back),
 			binding(keys.Enter),
-		})
+		}))
 
 	case types.StatePlaylistList:
-		return renderHelp([]key.Binding{
+		return renderHelp(withNowPlaying([]key.Binding{
 			binding(keys.Quit),
 			binding(keys.Back),
 			binding(keys.Enter),
-		})
+		}))
 
 	case types.StateDownload:
 		if cfg.IsCompleted || cfg.IsCancelled {
-			return renderHelp([]key.Binding{
+			return renderHelp(withNowPlaying([]key.Binding{
 				binding(keys.Quit),
 				binding(keys.Back),
 				binding(keys.Enter),
-			})
+			}))
 		}
 		dlKeys := []key.Binding{
 			binding(keys.Quit),
@@ -134,16 +140,16 @@ func getStatusBarText(m *Model, cfg StatusBarConfig) string {
 		if utils.PauseSupported() {
 			dlKeys = append([]key.Binding{dlKeys[0], binding(keys.Pause)}, dlKeys[1:]...)
 		}
-		return renderHelp(dlKeys)
+		return renderHelp(withNowPlaying(dlKeys))
 
 	case types.StatePlaylistOpts:
-		return renderHelp([]key.Binding{
+		return renderHelp(withNowPlaying([]key.Binding{
 			binding(keys.Quit),
 			binding(keys.Back),
 			binding(keys.Up),
 			binding(keys.Down),
 			binding(keys.Enter),
-		})
+		}))
 
 	case types.StateVideoPlaying:
 		return renderHelp([]key.Binding{
@@ -321,6 +327,7 @@ type StatusKeys struct {
 	Back            key.Binding
 	Enter           key.Binding
 	PlayVideo       key.Binding
+	NowPlaying      key.Binding
 	Pause           key.Binding
 	Cancel          key.Binding
 	Tab             key.Binding
@@ -373,7 +380,8 @@ func newCancelEscCKey() key.Binding {
 
 func GetStatusKeys(state types.State) StatusKeys {
 	keys := StatusKeys{
-		Quit: keymodels.SearchModelKeys.Quit,
+		Quit:       keymodels.SearchModelKeys.Quit,
+		NowPlaying: keymodels.GlobalModelKeys.NowPlaying,
 	}
 
 	switch state {

--- a/internal/utils/player.go
+++ b/internal/utils/player.go
@@ -41,6 +41,10 @@ func (pm *PlayerManager) Kill() {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
 
+	pm.killCurrentLocked()
+}
+
+func (pm *PlayerManager) killCurrentLocked() {
 	if pm.current == nil || pm.current.Process == nil {
 		return
 	}
@@ -56,6 +60,10 @@ func (pm *PlayerManager) Kill() {
 
 func (pm *PlayerManager) PlayURL(url string, ytdlFormat string, video types.VideoItem, program *tea.Program) tea.Cmd {
 	return func() tea.Msg {
+		pm.mu.Lock()
+		pm.killCurrentLocked()
+		pm.mu.Unlock()
+
 		args := make([]string, 0, 2)
 		if ytdlFormat != "" {
 			args = append(args, "--ytdl-format="+ytdlFormat)


### PR DESCRIPTION
## Summary

Keep media playback independent of TUI navigation so videos continue playing in `mpv` while you browse and select another video.

## Changes

* Leaving the **Now Playing** page no longer stops playback.
* `mpv` continues playing while you browse the app or perform a new search.
* Pressing `p` on another video replaces the current `mpv` playback with the newly selected video.
* Added `n` as a shortcut to return to the **Now Playing** page whenever playback is active.
* Updated help text and tests to reflect the new behavior.

## Testing

* Manually verified that playback continues after leaving the **Now Playing** page.
* Verified that starting playback for another video correctly replaces the existing `mpv` instance.
* Verified that `n` returns to the **Now Playing** page while playback is active.

---

Implemented with assistance from Codex / GPT-5.5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a **Now Playing** shortcut (press **“n”**) that appears in the status bar for relevant screens when a video is active.
  * Lets you jump to **Now Playing** and return to your previous location while retaining playback context.

* **Bug Fixes**
  * Improved back-navigation when leaving the player so you return to the correct prior screen.
  * Starting playback now stops any currently running player first.
  * The **“n”** shortcut is ignored when nothing is playing; exiting the player while browsing no longer alters the current state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->