### PR TITLE
fix: replace invalid --ffmpeg-path with --ffmpeg-location flag

Fixes #51

### DIFF
--- a/internal/utils/download.go
+++ b/internal/utils/download.go
@@ -161,9 +161,9 @@ func doDownload(dm *DownloadManager, program *tea.Program, req types.DownloadReq
 	}
 
 	if cfg.FFmpegPath != "" {
-		args = append([]string{"--ffmpeg-path", cfg.FFmpegPath}, args...)
+		args = append([]string{"--ffmpeg-location", cfg.FFmpegPath}, args...)
 	} else if autoPath := GetFFmpegAutoPath(); autoPath != "" {
-		args = append([]string{"--ffmpeg-path", autoPath}, args...)
+		args = append([]string{"--ffmpeg-location", autoPath}, args...)
 	}
 
 	if cfg.JSRuntime != "" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated download handling to use a more compatible FFmpeg path setting, which may improve media download reliability in more environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->