### PR TITLE
feat: spotify track info fetching & display

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ On first run, xytz will create the config file with default values if it doesn't
 ```yaml
 search_limit: 25 # Number of search results
 default_download_path: ~/Videos # Download destination
+spotify_download_path: ~/Music # Spotify download destination
 default_quality: best # Default format selection (480p, 720p, 1080p, 4k...)
 sort_by_default: relevance # Default sort: relevance, date, views, rating
 theme: catppuccin-mocha # Preset theme name

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type ResolvedConfig struct {
 type Config struct {
 	SearchLimit         int    `yaml:"search_limit"`
 	DefaultDownloadPath string `yaml:"default_download_path"`
+	SpotifyDownloadPath string `yaml:"spotify_download_path"`
 	DefaultQuality      string `yaml:"default_quality"`
 	SortByDefault       string `yaml:"sort_by_default"`
 	EmbedSubtitles      bool   `yaml:"embed_subtitles"`
@@ -106,6 +107,10 @@ func (c *Config) applyDefaults() {
 
 	if c.DefaultDownloadPath == "" {
 		c.DefaultDownloadPath = defaults.DefaultDownloadPath
+	}
+
+	if c.SpotifyDownloadPath == "" {
+		c.SpotifyDownloadPath = defaults.SpotifyDownloadPath
 	}
 
 	if c.DefaultQuality == "" {
@@ -201,6 +206,10 @@ func (c *Config) ExpandPath(path string) string {
 
 func (c *Config) GetDownloadPath() string {
 	return c.ExpandPath(c.DefaultDownloadPath)
+}
+
+func (c *Config) GetSpotifyDownloadPath() string {
+	return c.ExpandPath(c.SpotifyDownloadPath)
 }
 
 func (c *Config) validate() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -238,6 +238,26 @@ func TestGetDownloadPath(t *testing.T) {
 	}
 }
 
+func TestGetSpotifyDownloadPath(t *testing.T) {
+	cfg := &Config{
+		SpotifyDownloadPath: "~/Music",
+	}
+
+	path := cfg.GetSpotifyDownloadPath()
+	if path == "" {
+		t.Error("GetSpotifyDownloadPath() returned empty string")
+	}
+}
+
+func TestApplyDefaults_SpotifyDownloadPath(t *testing.T) {
+	cfg := &Config{}
+	cfg.applyDefaults()
+
+	if cfg.SpotifyDownloadPath != "~/Music" {
+		t.Errorf("applyDefaults() SpotifyDownloadPath = %q, want %q", cfg.SpotifyDownloadPath, "~/Music")
+	}
+}
+
 func TestValidate_VideoAndAudioFormat(t *testing.T) {
 	cfg := GetDefault()
 	cfg.VideoFormat = "nope"

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -4,6 +4,7 @@ func GetDefault() *Config {
 	return &Config{
 		SearchLimit:         25,
 		DefaultDownloadPath: "~/Videos",
+		SpotifyDownloadPath: "~/Music",
 		DefaultQuality:      "best",
 		SortByDefault:       "relevance",
 		EmbedSubtitles:      false,

--- a/internal/downloader/spotify_download.go
+++ b/internal/downloader/spotify_download.go
@@ -1,0 +1,510 @@
+package downloader
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	log "charm.land/log/v2"
+	"github.com/xdagiz/xytz/internal/config"
+	"github.com/xdagiz/xytz/internal/spotify"
+	"github.com/xdagiz/xytz/internal/types"
+	"github.com/xdagiz/xytz/internal/utils"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+const (
+	spotifyAudioFormat = "mp3"
+	maxCoverBytes      = 5 << 20 // 5 MiB
+	unsafeNameChars    = `[\/?:*"><|]`
+)
+
+var unsafeNameRe = regexp.MustCompile(unsafeNameChars)
+
+func SanitizeFilename(s string) string {
+	s = strings.TrimSpace(s)
+	s = unsafeNameRe.ReplaceAllString(s, "_")
+	s = strings.Map(func(r rune) rune {
+		if r < 32 || r == 127 {
+			return -1
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+	s = strings.Join(strings.Fields(s), " ")
+	s = strings.Trim(s, " .")
+
+	if s == "" {
+		s = "track"
+	}
+
+	return s
+}
+
+func sanitizeMetadata(s string) string {
+	s = strings.Map(func(r rune) rune {
+		switch {
+		case r == 0:
+			return -1
+		case r == '\n' || r == '\r' || r == '\t':
+			return ' '
+		case r < 32 || r == 127:
+			return -1
+		default:
+			return r
+		}
+	}, s)
+	return strings.TrimSpace(strings.Join(strings.Fields(s), " "))
+}
+
+func uniqueAudioPath(dir, baseName, ext string) (string, error) {
+	for i := range 999 {
+		var candidate string
+		if i == 0 {
+			candidate = filepath.Join(dir, baseName+"."+ext)
+		} else {
+			candidate = filepath.Join(dir, fmt.Sprintf("%s (%d).%s", baseName, i+1, ext))
+		}
+
+		f, err := os.OpenFile(candidate, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if err == nil {
+			f.Close()
+			_ = os.Remove(candidate)
+			return candidate, nil
+		}
+
+		if !os.IsExist(err) {
+			return "", err
+		}
+	}
+
+	timestamped := filepath.Join(dir, fmt.Sprintf("%s-%d.%s", baseName, time.Now().Unix(), ext))
+	f, err := os.OpenFile(timestamped, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err == nil {
+		f.Close()
+		_ = os.Remove(timestamped)
+		return timestamped, nil
+	}
+
+	return "", err
+}
+
+func durationMatchFilter(seconds float64) string {
+	if seconds <= 0 {
+		return ""
+	}
+
+	tol := 15.0
+	if pct := seconds * 0.08; pct > tol {
+		tol = pct
+	}
+
+	lo := seconds - tol
+	if lo < 0 {
+		lo = 0
+	}
+
+	hi := seconds + tol
+	return fmt.Sprintf("duration >= %.0f & duration <= %.0f", lo, hi)
+}
+
+func fetchImageToFile(ctx context.Context, rawURL, dest string) error {
+	if strings.TrimSpace(rawURL) == "" {
+		return fmt.Errorf("empty image url")
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("unsupported image url scheme %q", parsed.Scheme)
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", spotify.SpotifyUserAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("image fetch failed: status %d", resp.StatusCode)
+	}
+
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+
+	n, err := io.Copy(out, io.LimitReader(resp.Body, maxCoverBytes+1))
+	if err != nil {
+		out.Close()
+		os.Remove(dest)
+		return err
+	}
+
+	if n > maxCoverBytes {
+		out.Close()
+		os.Remove(dest)
+		return fmt.Errorf("image too large (>%d bytes)", maxCoverBytes)
+	}
+
+	return out.Close()
+}
+
+func buildSpotifyYtArgs(outTmpl, searchQuery, ffmpegPath, cb, c, matchFilter string, useFilter bool) []string {
+	searchPrefix := "ytsearch1:"
+	if useFilter {
+		searchPrefix = "ytsearch5:"
+	}
+
+	ytArgs := []string{
+		searchPrefix + searchQuery,
+		"-f", "bestaudio",
+		"--no-playlist",
+		"-x",
+		"--audio-format", spotifyAudioFormat,
+		"--audio-quality", "0",
+		"--no-mtime",
+		"--newline",
+		"-R", "10",
+		"-o", outTmpl,
+	}
+
+	if useFilter && matchFilter != "" {
+		ytArgs = append(ytArgs, "--match-filter", matchFilter)
+	}
+
+	if cb != "" {
+		ytArgs = append(ytArgs, "--cookies-from-browser", cb)
+	} else if c != "" {
+		ytArgs = append(ytArgs, "--cookies", c)
+	}
+
+	if ffmpegPath != "" {
+		ytArgs = append(ytArgs, "--ffmpeg-location", ffmpegPath)
+	}
+
+	return ytArgs
+}
+
+func cleanupStemArtifacts(dir, stem string) {
+	if dir == "" || stem == "" {
+		return
+	}
+
+	matches, err := filepath.Glob(filepath.Join(dir, stem+".*"))
+	if err != nil {
+		return
+	}
+	for _, m := range matches {
+		_ = os.Remove(m)
+	}
+}
+
+func StartSpotifyTrackDownload(dm *DownloadManager, cfg *config.Config, program *tea.Program, req types.StartSpotifyTrackDownloadMsg) tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		go doSpotifyTrackDownload(dm, program, req, cfg)
+		return nil
+	})
+}
+
+func doSpotifyTrackDownload(dm *DownloadManager, program *tea.Program, req types.StartSpotifyTrackDownloadMsg, cfg *config.Config) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	dm.SetContext(ctx, cancel)
+	defer dm.Clear()
+
+	ytdlpPath := "yt-dlp"
+	if cfg.YTDLPPath != "" {
+		ytdlpPath = cfg.YTDLPPath
+	}
+
+	ffmpegPath := cfg.FFmpegPath
+	if ffmpegPath == "" {
+		if p := utils.GetFFmpegAutoPath(); p != "" {
+			ffmpegPath = p
+		}
+	}
+
+	track := req.Track
+	format := spotifyAudioFormat
+
+	downloadPath := cfg.GetSpotifyDownloadPath()
+	baseName := SanitizeFilename(fmt.Sprintf("%s - %s", track.Artist, track.Title))
+
+	finalPath, err := uniqueAudioPath(downloadPath, baseName, format)
+	if err != nil {
+		program.Send(types.DownloadResultMsg{
+			Err:         fmt.Sprintf("Failed to create output path: %v", err),
+			OperationID: req.OperationID,
+		})
+		return
+	}
+
+	stem := strings.TrimSuffix(filepath.Base(finalPath), "."+format)
+	outTmpl := filepath.Join(downloadPath, stem+".%(ext)s")
+
+	fail := func(errMsg string) {
+		cleanupStemArtifacts(downloadPath, stem)
+		program.Send(types.DownloadResultMsg{Err: errMsg, OperationID: req.OperationID})
+	}
+
+	status := func(label string, percent float64) {
+		program.Send(types.ProgressMsg{
+			Percent:     percent,
+			Status:      label,
+			Title:       track.Title,
+			OperationID: req.OperationID,
+		})
+	}
+
+	searchQuery := fmt.Sprintf("%s - %s official audio", track.Artist, track.Title)
+	searchQuery = strings.NewReplacer(":", "", "\"", "").Replace(searchQuery)
+
+	cb := req.CookiesFromBrowser
+	if cb == "" {
+		cb = cfg.CookiesBrowser
+	}
+
+	c := req.Cookies
+	if c == "" {
+		c = cfg.CookiesFile
+	}
+
+	matchFilter := durationMatchFilter(track.Duration)
+	useFilter := matchFilter != ""
+
+	ytArgs := buildSpotifyYtArgs(outTmpl, searchQuery, ffmpegPath, cb, c, matchFilter, useFilter)
+
+	cmd := exec.CommandContext(ctx, ytdlpPath, ytArgs...)
+	dm.SetCmd(cmd)
+	dm.SetPaused(false)
+
+	if err := streamDownload(program, cmd, track, format, req.OperationID); err != nil {
+		if ctx.Err() == context.Canceled {
+			fail("Download cancelled")
+			return
+		}
+
+		if !useFilter {
+			fail(fmt.Sprintf("Download error: %v", err))
+			return
+		}
+
+		status("Retrying without duration filter…", 0)
+
+		cleanupStemArtifacts(downloadPath, stem)
+
+		ytArgs = buildSpotifyYtArgs(outTmpl, searchQuery, ffmpegPath, cb, c, "", false)
+		cmd = exec.CommandContext(ctx, ytdlpPath, ytArgs...)
+		dm.SetCmd(cmd)
+		dm.SetPaused(false)
+
+		if err2 := streamDownload(program, cmd, track, format, req.OperationID); err2 != nil {
+			if ctx.Err() == context.Canceled {
+				fail("Download cancelled")
+				return
+			}
+			fail(fmt.Sprintf("Download error: %v", err2))
+			return
+		}
+	}
+
+	if _, statErr := os.Stat(finalPath); statErr != nil {
+		if ctx.Err() == context.Canceled {
+			fail("Download cancelled")
+			return
+		}
+		fail("yt-dlp produced no audio file")
+		return
+	}
+
+	status("Fetching cover…", 100)
+
+	coverPath := filepath.Join(downloadPath, stem+".cover.jpg")
+	if err := fetchImageToFile(ctx, track.CoverURL, coverPath); err != nil {
+		log.Warn("spotify cover fetch failed, continuing without it", "err", err)
+		coverPath = ""
+	} else if ctx.Err() == context.Canceled {
+		fail("Download cancelled")
+		return
+	}
+
+	if ffmpegPath != "" {
+		status("Processing…", 100)
+
+		if err := tagAudioFile(ctx, dm, ffmpegPath, finalPath, coverPath, track, format); err != nil {
+			if ctx.Err() == context.Canceled {
+				fail("Download cancelled")
+				return
+			}
+			log.Error("ffmpeg tag/cover step failed, keeping raw audio", "err", err)
+		}
+	}
+
+	if coverPath != "" {
+		_ = os.Remove(coverPath)
+	}
+
+	if ctx.Err() == context.Canceled {
+		fail("Download cancelled")
+		return
+	}
+
+	program.Send(types.DownloadResultMsg{
+		Output:      "Download complete",
+		Destination: finalPath,
+		OperationID: req.OperationID,
+	})
+}
+
+func runFFmpeg(ffmpegPath string, args []string, ctx context.Context, dm *DownloadManager) error {
+	cmd := exec.CommandContext(ctx, ffmpegPath, args...)
+	if dm != nil {
+		dm.SetCmd(cmd)
+		dm.SetPaused(false)
+	}
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	if err := cmd.Run(); err != nil {
+		log.Error("ffmpeg failed", "err", err, "out", buf.String())
+		return err
+	}
+
+	return nil
+}
+
+func streamDownload(program *tea.Program, cmd *exec.Cmd, track types.SpotifyTrack, format string, opID string) error {
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("pipe error: %w", err)
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("stderr pipe error: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start error: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	readPipe := func(pipe io.Reader) {
+		parser := NewProgressParser()
+		parser.ReadPipe(pipe, func(percent float64, speed, eta, status, destination string) {
+			program.Send(types.ProgressMsg{
+				Percent:       percent,
+				Speed:         speed,
+				Eta:           eta,
+				Status:        status,
+				Destination:   destination,
+				FileExtension: format,
+				Title:         track.Title,
+				OperationID:   opID,
+			})
+		})
+	}
+
+	wg.Go(func() {
+		readPipe(stdout)
+	})
+	wg.Go(func() {
+		readPipe(stderr)
+	})
+
+	err = cmd.Wait()
+	_ = stdout.Close()
+	_ = stderr.Close()
+	wg.Wait()
+	return err
+}
+
+func tagAudioFile(ctx context.Context, dm *DownloadManager, ffmpegPath, finalPath, coverPath string, track types.SpotifyTrack, format string) error {
+	taggedTmp := finalPath + ".tmp." + format
+	ffArgs := buildSpotifyTagArgs(finalPath, coverPath, taggedTmp, format, track)
+
+	if err := runFFmpeg(ffmpegPath, ffArgs, ctx, dm); err != nil {
+		_ = os.Remove(taggedTmp)
+		return err
+	}
+
+	return os.Rename(taggedTmp, finalPath)
+}
+
+func buildSpotifyTagArgs(finalPath, coverPath, taggedTmp, format string, track types.SpotifyTrack) []string {
+	ffArgs := []string{"-y", "-i", finalPath}
+	if coverPath != "" {
+		ffArgs = append(ffArgs, "-i", coverPath)
+	}
+
+	ffArgs = append(ffArgs, "-map", "0:a")
+	if coverPath != "" {
+		ffArgs = append(ffArgs, "-map", "1:v?")
+	}
+
+	ffArgs = append(ffArgs, "-c:a", "copy")
+	if coverPath != "" {
+		ffArgs = append(ffArgs, "-c:v", "mjpeg", "-disposition:v", "attached_pic")
+	}
+
+	artist := sanitizeMetadata(track.Artist)
+	album := sanitizeMetadata(track.Album)
+	title := sanitizeMetadata(track.Title)
+	date := sanitizeMetadata(track.ReleaseDate)
+
+	ffArgs = append(ffArgs,
+		"-metadata", "artist="+artist,
+		"-metadata", "title="+title,
+	)
+
+	if album != "" {
+		ffArgs = append(ffArgs, "-metadata", "album="+album)
+	}
+
+	if track.TrackNum > 0 {
+		ffArgs = append(ffArgs, "-metadata", fmt.Sprintf("track=%d", track.TrackNum))
+	}
+
+	if track.DiscNum > 0 {
+		ffArgs = append(ffArgs, "-metadata", fmt.Sprintf("disc=%d", track.DiscNum))
+	}
+
+	if date != "" {
+		ffArgs = append(ffArgs, "-metadata", "date="+date)
+	}
+
+	if format == spotifyAudioFormat {
+		ffArgs = append(ffArgs, "-id3v2_version", "3")
+	}
+
+	ffArgs = append(ffArgs, taggedTmp)
+
+	return ffArgs
+}

--- a/internal/downloader/spotify_download_test.go
+++ b/internal/downloader/spotify_download_test.go
@@ -1,0 +1,121 @@
+package downloader
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeName(t *testing.T) {
+	if got := SanitizeFilename(`A/B:C*D?"E<F>G|H`); strings.ContainsAny(got, `/?:*"<|>|`) {
+		t.Fatalf("unsafe chars remain: %q", got)
+	}
+	if got := SanitizeFilename("   "); got != "track" {
+		t.Fatalf("empty = %q", got)
+	}
+	if got := SanitizeFilename("  hello world.  "); got != "hello world" {
+		t.Fatalf("trim dots/spaces = %q", got)
+	}
+	if got := SanitizeFilename("a\x00b\nc"); strings.ContainsAny(got, "\x00\n\r") {
+		t.Fatalf("control chars remain: %q", got)
+	}
+	if got := SanitizeFilename("Foo/Bar"); got != "Foo_Bar" {
+		t.Fatalf("SanitizeFilename = %q", got)
+	}
+}
+
+func TestSanitizeMetadata(t *testing.T) {
+	// newline → space, NUL stripped, then fields collapsed
+	if got := sanitizeMetadata("  A\nB\x00C  "); got != "A BC" {
+		t.Fatalf("sanitizeMetadata = %q", got)
+	}
+	if got := sanitizeMetadata("A\n\nB"); got != "A B" {
+		t.Fatalf("multi newline = %q", got)
+	}
+}
+
+func TestCleanupStemArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	stem := "Artist - Title"
+	keep := filepath.Join(dir, "other.mp3")
+	if err := os.WriteFile(keep, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{stem + ".mp3", stem + ".webm", stem + ".cover.jpg", stem + ".mp3.part"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cleanupStemArtifacts(dir, stem)
+	for _, name := range []string{stem + ".mp3", stem + ".webm", stem + ".cover.jpg", stem + ".mp3.part"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Fatalf("expected %s removed", name)
+		}
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Fatalf("unrelated file should remain: %v", err)
+	}
+}
+
+func TestBuildSpotifyYtArgsUsesExtTemplate(t *testing.T) {
+	args := buildSpotifyYtArgs("/tmp/stem.%(ext)s", "query", "", "", "", "", false)
+	found := false
+	for i, a := range args {
+		if a == "-o" && i+1 < len(args) {
+			if args[i+1] != "/tmp/stem.%(ext)s" {
+				t.Fatalf("-o = %q", args[i+1])
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("missing -o")
+	}
+}
+
+func TestUniqueAudioPath(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := uniqueAudioPath(dir, "Artist - Title", "mp3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(dir, "Artist - Title.mp3"); first != want {
+		t.Fatalf("first = %q, want %q", first, want)
+	}
+
+	// Simulate a concurrent claim by creating the file.
+	if err := os.WriteFile(first, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := uniqueAudioPath(dir, "Artist - Title", "mp3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(dir, "Artist - Title (2).mp3"); second != want {
+		t.Fatalf("second = %q, want %q", second, want)
+	}
+}
+
+func TestDurationMatchFilter(t *testing.T) {
+	if got := durationMatchFilter(0); got != "" {
+		t.Fatalf("zero duration filter = %q", got)
+	}
+	got := durationMatchFilter(200)
+	// 8% of 200 = 16 > 15 → percentage wins
+	if got != "duration >= 184 & duration <= 216" {
+		t.Fatalf("filter = %q", got)
+	}
+	// 8% of 300 = 24 > 15 → use percentage tolerance
+	got = durationMatchFilter(300)
+	if got != "duration >= 276 & duration <= 324" {
+		t.Fatalf("filter = %q", got)
+	}
+	// short track: fixed 15s tolerance (8% of 100 = 8 < 15)
+	got = durationMatchFilter(100)
+	if got != "duration >= 85 & duration <= 115" {
+		t.Fatalf("filter = %q", got)
+	}
+}

--- a/internal/spotify/spotify.go
+++ b/internal/spotify/spotify.go
@@ -1,0 +1,291 @@
+package spotify
+
+import (
+	"fmt"
+	"html"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/xdagiz/xytz/internal/types"
+)
+
+const (
+	spotifyUserAgent      = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
+	spotifyAcceptLanguage = "en"
+	middotSep             = " · "
+)
+
+var metaTagRe = regexp.MustCompile(
+	`(?is)<meta\b[^>]*?(?:property|name)="([^"]+)"[^>]*?content="([^"]*)"[^>]*>` +
+		`|` +
+		`(?is)<meta\b[^>]*?content="([^"]*)"[^>]*?(?:property|name)="([^"]+)"[^>]*>`,
+)
+
+type metaTag struct {
+	property string
+	content  string
+}
+
+func IsSpotifyURL(u string) bool {
+	u = strings.ToLower(strings.TrimSpace(u))
+	return strings.Contains(u, "open.spotify.com") ||
+		strings.HasPrefix(u, "spotify:") ||
+		strings.Contains(u, "spotify.link")
+}
+
+var spotifyURLRe = regexp.MustCompile(`open\.spotify\.com/(?:intl-[a-z]{2}/)?(?:embed/)?(track|album|playlist)/([A-Za-z0-9]+)`)
+
+func normalizeURL(input string) string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ""
+	}
+
+	if !strings.HasPrefix(input, "http://") && !strings.HasPrefix(input, "https://") {
+		if strings.Contains(input, ".") && !strings.Contains(input, " ") {
+			return "https://" + input
+		}
+	}
+
+	return input
+}
+
+func ParseSpotifyURL(u string) (types.SpotifyEntityType, string, error) {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		return "", "", fmt.Errorf("empty url")
+	}
+
+	if strings.HasPrefix(u, "spotify:") {
+		parts := strings.Split(u, ":")
+		if len(parts) >= 3 {
+			entity := types.SpotifyEntityType(parts[1])
+			switch entity {
+			case types.SpotifyEntityTrack, types.SpotifyEntityAlbum, types.SpotifyEntityPlaylist:
+				return entity, parts[2], nil
+			case "artist":
+				return entity, parts[2], fmt.Errorf("artist links are not supported")
+			default:
+				return "", "", fmt.Errorf("unsupported spotify uri type %q", parts[1])
+			}
+		}
+		return "", "", fmt.Errorf("invalid spotify uri")
+	}
+
+	normalized := normalizeURL(u)
+	if normalized == "" {
+		return "", "", fmt.Errorf("invalid url")
+	}
+
+	if strings.Contains(normalized, "spotify.link") {
+		return "", normalized, fmt.Errorf("spotify short links are not supported yet")
+	}
+
+	parsed, perr := url.Parse(normalized)
+	if perr != nil {
+		return "", "", fmt.Errorf("not a recognized spotify url")
+	}
+	if parsed.Host != "open.spotify.com" {
+		return "", "", fmt.Errorf("not a recognized spotify url")
+	}
+
+	if strings.Contains(parsed.Path, "/artist/") {
+		return types.SpotifyEntityType("artist"), "", fmt.Errorf("artist links are not supported")
+	}
+
+	m := spotifyURLRe.FindStringSubmatch(normalized)
+	if m == nil {
+		return "", "", fmt.Errorf("not a recognized spotify url")
+	}
+
+	return types.SpotifyEntityType(m[1]), m[2], nil
+}
+
+func FetchSpotifyTrackCmd(url string) tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		return FetchSpotifyTrack(url)
+	})
+}
+
+func FetchSpotifyTrack(url string) types.SpotifyTrackResultMsg {
+	entityType, id, err := ParseSpotifyURL(url)
+	if err != nil {
+		return types.SpotifyTrackResultMsg{Err: err.Error()}
+	}
+
+	if entityType != types.SpotifyEntityTrack {
+		return types.SpotifyTrackResultMsg{
+			Type: entityType,
+			Err:  fmt.Sprintf("%s links are not supported yet (only track)", entityType),
+		}
+	}
+
+	fetchURL := url
+	if strings.HasPrefix(url, "spotify:") {
+		fetchURL = "https://open.spotify.com/" + string(entityType) + "/" + id
+	} else {
+		fetchURL = "https://open.spotify.com/track/" + id
+	}
+
+	htmlBody, err := fetchSpotifyHTML(fetchURL)
+	if err != nil {
+		return types.SpotifyTrackResultMsg{Type: entityType, Err: err.Error()}
+	}
+
+	if isSpotifyBotChallenge(htmlBody) {
+		return types.SpotifyTrackResultMsg{
+			Type: entityType,
+			Err:  "spotify returned a page without track metadata (possible bot challenge or rate limit); try again later",
+		}
+	}
+
+	tags := parseMetaTags(htmlBody)
+	if len(tags) == 0 {
+		return types.SpotifyTrackResultMsg{Type: entityType, Err: "failed to parse Spotify page"}
+	}
+
+	track := buildTrackFromMeta(tags, id, fetchURL)
+	if track == nil {
+		return types.SpotifyTrackResultMsg{Type: entityType, Err: "could not extract track metadata"}
+	}
+
+	return types.SpotifyTrackResultMsg{Type: entityType, Track: track}
+}
+
+func fetchSpotifyHTML(url string) (string, error) {
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", spotifyUserAgent)
+	req.Header.Set("Accept-Language", spotifyAcceptLanguage)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "", fmt.Errorf("spotify returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+func parseMetaTags(htmlBody string) []metaTag {
+	var out []metaTag
+
+	matches := metaTagRe.FindAllStringSubmatch(htmlBody, -1)
+	for _, m := range matches {
+		var prop, content string
+		if m[1] != "" {
+			prop, content = m[1], m[2]
+		} else {
+			prop, content = m[4], m[3]
+		}
+
+		if prop == "" {
+			continue
+		}
+
+		out = append(out, metaTag{
+			property: prop,
+			content:  html.UnescapeString(content),
+		})
+	}
+
+	return out
+}
+
+func metaContent(tags []metaTag, property string) string {
+	for _, t := range tags {
+		if t.property == property {
+			return t.content
+		}
+	}
+	return ""
+}
+
+func isSpotifyBotChallenge(htmlBody string) bool {
+	return !strings.Contains(htmlBody, "og:title")
+}
+
+func buildTrackFromMeta(tags []metaTag, id, url string) *types.SpotifyTrack {
+	title := strings.TrimSpace(metaContent(tags, "og:title"))
+	if title == "" {
+		return nil
+	}
+
+	cover := metaContent(tags, "og:image")
+	desc := metaContent(tags, "og:description")
+	artist := strings.TrimSpace(metaContent(tags, "music:musician_description"))
+	release := strings.TrimSpace(metaContent(tags, "music:release_date"))
+	duration := parseFloatOrZero(metaContent(tags, "music:duration"))
+	trackNum := parseIntOrZero(metaContent(tags, "music:album:track"))
+	discNum := parseIntOrZero(metaContent(tags, "music:album:disc"))
+	album := ""
+
+	descParts := strings.Split(desc, middotSep)
+	if len(descParts) >= 2 {
+		if artist == "" {
+			artist = strings.TrimSpace(descParts[0])
+		}
+
+		album = strings.TrimSpace(descParts[1])
+	}
+
+	return &types.SpotifyTrack{
+		SpotifyTrackItem: types.SpotifyTrackItem{
+			ID:         id,
+			Title:      title,
+			Artist:     artist,
+			Album:      album,
+			Duration:   duration,
+			TrackNum:   trackNum,
+			DiscNum:    discNum,
+			CoverURL:   cover,
+			SpotifyURL: url,
+		},
+		ReleaseDate: release,
+	}
+}
+
+func parseFloatOrZero(s string) float64 {
+	if s == "" {
+		return 0
+	}
+
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0
+	}
+
+	return f
+}
+
+func parseIntOrZero(s string) int {
+	if s == "" {
+		return 0
+	}
+
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+
+	return i
+}

--- a/internal/spotify/spotify.go
+++ b/internal/spotify/spotify.go
@@ -1,6 +1,7 @@
 package spotify
 
 import (
+	"context"
 	"fmt"
 	"html"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -16,15 +18,17 @@ import (
 )
 
 const (
-	spotifyUserAgent      = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
+	SpotifyUserAgent      = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)"
 	spotifyAcceptLanguage = "en"
 	middotSep             = " · "
+	maxHTMLBytes          = 1 << 20
+	httpTimeout           = 15 * time.Second
 )
 
-var metaTagRe = regexp.MustCompile(
-	`(?is)<meta\b[^>]*?(?:property|name)="([^"]+)"[^>]*?content="([^"]*)"[^>]*>` +
-		`|` +
-		`(?is)<meta\b[^>]*?content="([^"]*)"[^>]*?(?:property|name)="([^"]+)"[^>]*>`,
+var (
+	metaOpenRe   = regexp.MustCompile(`(?is)<meta\b([^>]*)/?>`)
+	metaAttrRe   = regexp.MustCompile(`(?i)\b(property|name|content)\s*=\s*(?:"([^"]*)"|'([^']*)')`)
+	spotifyURLRe = regexp.MustCompile(`^(?i:(?:www\.)?open\.spotify\.com)/(?:intl-[a-z]{2}/)?(?:embed/)?(track|album|playlist)/([A-Za-z0-9]+)/?$`)
 )
 
 type metaTag struct {
@@ -32,14 +36,78 @@ type metaTag struct {
 	content  string
 }
 
-func IsSpotifyURL(u string) bool {
-	u = strings.ToLower(strings.TrimSpace(u))
-	return strings.Contains(u, "open.spotify.com") ||
-		strings.HasPrefix(u, "spotify:") ||
-		strings.Contains(u, "spotify.link")
+type FetchManager struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	gen    uint64
 }
 
-var spotifyURLRe = regexp.MustCompile(`open\.spotify\.com/(?:intl-[a-z]{2}/)?(?:embed/)?(track|album|playlist)/([A-Za-z0-9]+)`)
+type FetchToken uint64
+
+func NewFetchManager() *FetchManager {
+	return &FetchManager{}
+}
+
+func (fm *FetchManager) Begin() (context.Context, FetchToken) {
+	if fm == nil {
+		return context.Background(), 0
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	prev := fm.cancel
+
+	fm.mu.Lock()
+	fm.gen++
+	tok := FetchToken(fm.gen)
+	fm.cancel = cancel
+	fm.mu.Unlock()
+
+	if prev != nil {
+		prev()
+	}
+
+	return ctx, tok
+}
+
+func (fm *FetchManager) Cancel() {
+	if fm == nil {
+		return
+	}
+
+	fm.mu.Lock()
+	cancel := fm.cancel
+	fm.cancel = nil
+	fm.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (fm *FetchManager) Clear(tok FetchToken) {
+	if fm == nil {
+		return
+	}
+
+	fm.mu.Lock()
+	if fm.gen == uint64(tok) && fm.cancel != nil {
+		fm.cancel()
+		fm.cancel = nil
+	}
+	fm.mu.Unlock()
+}
+
+func IsSpotifyURL(u string) bool {
+	u = strings.TrimSpace(u)
+	if strings.HasPrefix(strings.ToLower(u), "spotify:") {
+		return true
+	}
+
+	parsed, err := url.Parse(normalizeURL(u))
+	return err == nil &&
+		(isOpenSpotifyHost(parsed.Hostname()) ||
+			isSpotifyLinkHost(parsed.Hostname()))
+}
 
 func normalizeURL(input string) string {
 	input = strings.TrimSpace(input)
@@ -56,6 +124,16 @@ func normalizeURL(input string) string {
 	return input
 }
 
+func isOpenSpotifyHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "open.spotify.com" || host == "www.open.spotify.com"
+}
+
+func isSpotifyLinkHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "spotify.link" || host == "www.spotify.link"
+}
+
 func ParseSpotifyURL(u string) (types.SpotifyEntityType, string, error) {
 	u = strings.TrimSpace(u)
 	if u == "" {
@@ -70,7 +148,7 @@ func ParseSpotifyURL(u string) (types.SpotifyEntityType, string, error) {
 			case types.SpotifyEntityTrack, types.SpotifyEntityAlbum, types.SpotifyEntityPlaylist:
 				return entity, parts[2], nil
 			case "artist":
-				return entity, parts[2], fmt.Errorf("artist links are not supported")
+				return "", "", fmt.Errorf("artist links are not supported")
 			default:
 				return "", "", fmt.Errorf("unsupported spotify uri type %q", parts[1])
 			}
@@ -83,23 +161,25 @@ func ParseSpotifyURL(u string) (types.SpotifyEntityType, string, error) {
 		return "", "", fmt.Errorf("invalid url")
 	}
 
-	if strings.Contains(normalized, "spotify.link") {
-		return "", normalized, fmt.Errorf("spotify short links are not supported yet")
-	}
-
 	parsed, perr := url.Parse(normalized)
 	if perr != nil {
 		return "", "", fmt.Errorf("not a recognized spotify url")
 	}
-	if parsed.Host != "open.spotify.com" {
+
+	host := parsed.Hostname()
+	if isSpotifyLinkHost(host) {
+		return "", "", fmt.Errorf("spotify short links must be resolved before parsing")
+	}
+
+	if !isOpenSpotifyHost(host) {
 		return "", "", fmt.Errorf("not a recognized spotify url")
 	}
 
 	if strings.Contains(parsed.Path, "/artist/") {
-		return types.SpotifyEntityType("artist"), "", fmt.Errorf("artist links are not supported")
+		return "", "", fmt.Errorf("artist links are not supported")
 	}
 
-	m := spotifyURLRe.FindStringSubmatch(normalized)
+	m := spotifyURLRe.FindStringSubmatch(parsed.Hostname() + parsed.Path)
 	if m == nil {
 		return "", "", fmt.Errorf("not a recognized spotify url")
 	}
@@ -107,14 +187,41 @@ func ParseSpotifyURL(u string) (types.SpotifyEntityType, string, error) {
 	return types.SpotifyEntityType(m[1]), m[2], nil
 }
 
-func FetchSpotifyTrackCmd(url string) tea.Cmd {
+func FetchSpotifyTrackCmd(fm *FetchManager, trackURL string) tea.Cmd {
 	return tea.Cmd(func() tea.Msg {
-		return FetchSpotifyTrack(url)
+		ctx := context.Background()
+		var tok FetchToken
+		if fm != nil {
+			ctx, tok = fm.Begin()
+			defer fm.Clear(tok)
+		}
+		return FetchSpotifyTrack(ctx, trackURL)
 	})
 }
 
-func FetchSpotifyTrack(url string) types.SpotifyTrackResultMsg {
-	entityType, id, err := ParseSpotifyURL(url)
+func CancelFetch(fm *FetchManager) tea.Cmd {
+	return tea.Cmd(func() tea.Msg {
+		if fm != nil {
+			fm.Cancel()
+		}
+		return types.CancelSpotifyFetchMsg{}
+	})
+}
+
+func FetchSpotifyTrack(ctx context.Context, trackURL string) types.SpotifyTrackResultMsg {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	resolved, err := resolveSpotifyURL(ctx, trackURL)
+	if err != nil {
+		if ctx.Err() != nil {
+			return types.SpotifyTrackResultMsg{Err: "cancelled"}
+		}
+		return types.SpotifyTrackResultMsg{Err: err.Error()}
+	}
+
+	entityType, id, err := ParseSpotifyURL(resolved)
 	if err != nil {
 		return types.SpotifyTrackResultMsg{Err: err.Error()}
 	}
@@ -126,23 +233,18 @@ func FetchSpotifyTrack(url string) types.SpotifyTrackResultMsg {
 		}
 	}
 
-	fetchURL := url
-	if strings.HasPrefix(url, "spotify:") {
-		fetchURL = "https://open.spotify.com/" + string(entityType) + "/" + id
-	} else {
-		fetchURL = "https://open.spotify.com/track/" + id
-	}
+	fetchURL := "https://open.spotify.com/track/" + id
 
-	htmlBody, err := fetchSpotifyHTML(fetchURL)
+	htmlBody, err := fetchSpotifyHTML(ctx, fetchURL)
 	if err != nil {
+		if ctx.Err() != nil {
+			return types.SpotifyTrackResultMsg{Type: entityType, Err: "cancelled"}
+		}
 		return types.SpotifyTrackResultMsg{Type: entityType, Err: err.Error()}
 	}
 
-	if isSpotifyBotChallenge(htmlBody) {
-		return types.SpotifyTrackResultMsg{
-			Type: entityType,
-			Err:  "spotify returned a page without track metadata (possible bot challenge or rate limit); try again later",
-		}
+	if err := validateSpotifyTrackPage(htmlBody); err != nil {
+		return types.SpotifyTrackResultMsg{Type: entityType, Err: err.Error()}
 	}
 
 	tags := parseMetaTags(htmlBody)
@@ -158,14 +260,59 @@ func FetchSpotifyTrack(url string) types.SpotifyTrackResultMsg {
 	return types.SpotifyTrackResultMsg{Type: entityType, Track: track}
 }
 
-func fetchSpotifyHTML(url string) (string, error) {
-	client := &http.Client{Timeout: 15 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+func resolveSpotifyURL(ctx context.Context, raw string) (string, error) {
+	normalized := normalizeURL(raw)
+	if normalized == "" {
+		return raw, nil
+	}
+
+	parsed, err := url.Parse(normalized)
+	if err != nil || !isSpotifyLinkHost(parsed.Hostname()) {
+		return raw, nil
+	}
+
+	client := &http.Client{
+		Timeout: httpTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, normalized, nil)
 	if err != nil {
 		return "", err
 	}
 
-	req.Header.Set("User-Agent", spotifyUserAgent)
+	req.Header.Set("User-Agent", SpotifyUserAgent)
+	req.Header.Set("Accept-Language", spotifyAcceptLanguage)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve short link: %w", err)
+	}
+
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64<<10))
+
+	final := resp.Request.URL.String()
+	if !isOpenSpotifyHost(resp.Request.URL.Hostname()) {
+		return "", fmt.Errorf("short link did not resolve to open.spotify.com")
+	}
+
+	return final, nil
+}
+
+func fetchSpotifyHTML(ctx context.Context, pageURL string) (string, error) {
+	client := &http.Client{Timeout: httpTimeout}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pageURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", SpotifyUserAgent)
 	req.Header.Set("Accept-Language", spotifyAcceptLanguage)
 
 	resp, err := client.Do(req)
@@ -178,7 +325,7 @@ func fetchSpotifyHTML(url string) (string, error) {
 		return "", fmt.Errorf("spotify returned status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTMLBytes))
 	if err != nil {
 		return "", err
 	}
@@ -189,13 +336,23 @@ func fetchSpotifyHTML(url string) (string, error) {
 func parseMetaTags(htmlBody string) []metaTag {
 	var out []metaTag
 
-	matches := metaTagRe.FindAllStringSubmatch(htmlBody, -1)
+	matches := metaOpenRe.FindAllStringSubmatch(htmlBody, -1)
 	for _, m := range matches {
-		var prop, content string
-		if m[1] != "" {
-			prop, content = m[1], m[2]
-		} else {
-			prop, content = m[4], m[3]
+		attrs := m[1]
+		prop := ""
+		content := ""
+		for _, a := range metaAttrRe.FindAllStringSubmatch(attrs, -1) {
+			key := strings.ToLower(a[1])
+			val := a[2]
+			if val == "" {
+				val = a[3]
+			}
+			switch key {
+			case "property", "name":
+				prop = val
+			case "content":
+				content = val
+			}
 		}
 
 		if prop == "" {
@@ -220,17 +377,41 @@ func metaContent(tags []metaTag, property string) string {
 	return ""
 }
 
-func isSpotifyBotChallenge(htmlBody string) bool {
-	return !strings.Contains(htmlBody, "og:title")
+func hasOGTitle(htmlBody string) bool {
+	return strings.TrimSpace(
+		metaContent(parseMetaTags(htmlBody), "og:title"),
+	) != ""
 }
 
-func buildTrackFromMeta(tags []metaTag, id, url string) *types.SpotifyTrack {
+func validateSpotifyTrackPage(htmlBody string) error {
+	if hasOGTitle(htmlBody) {
+		return nil
+	}
+
+	lower := strings.ToLower(htmlBody)
+	switch {
+	case strings.Contains(lower, "captcha"),
+		strings.Contains(lower, "cf-browser-verification"),
+		strings.Contains(lower, "challenge-platform"),
+		strings.Contains(lower, "bot detection"):
+		return fmt.Errorf("spotify returned a bot challenge; try again later")
+	case len(strings.TrimSpace(htmlBody)) < 500:
+		return fmt.Errorf("spotify returned an empty or blocked page; try again later")
+	default:
+		return fmt.Errorf("spotify page missing track metadata; try again later")
+	}
+}
+
+func buildTrackFromMeta(tags []metaTag, id, pageURL string) *types.SpotifyTrack {
 	title := strings.TrimSpace(metaContent(tags, "og:title"))
 	if title == "" {
 		return nil
 	}
 
-	cover := metaContent(tags, "og:image")
+	// Album pages use "Title - Album by Artist | Spotify"; strip that suffix if present.
+	title = strings.TrimSpace(strings.TrimSuffix(title, " | Spotify"))
+	cover := strings.TrimSpace(metaContent(tags, "og:image"))
+	ogType := strings.TrimSpace(metaContent(tags, "og:type"))
 	desc := metaContent(tags, "og:description")
 	artist := strings.TrimSpace(metaContent(tags, "music:musician_description"))
 	release := strings.TrimSpace(metaContent(tags, "music:release_date"))
@@ -240,12 +421,30 @@ func buildTrackFromMeta(tags []metaTag, id, url string) *types.SpotifyTrack {
 	album := ""
 
 	descParts := strings.Split(desc, middotSep)
+	for i := range descParts {
+		descParts[i] = strings.TrimSpace(descParts[i])
+	}
+
 	if len(descParts) >= 2 {
 		if artist == "" {
-			artist = strings.TrimSpace(descParts[0])
+			artist = descParts[0]
 		}
 
-		album = strings.TrimSpace(descParts[1])
+		// Track pages: "Artist · Album · Song · Year"
+		// Skip generic tokens when picking album.
+		for _, part := range descParts[1:] {
+			lower := strings.ToLower(part)
+			if lower == "song" || lower == "album" || lower == "single" || lower == "ep" {
+				continue
+			}
+
+			if _, err := strconv.Atoi(part); err == nil && len(part) == 4 {
+				continue // year
+			}
+
+			album = part
+			break
+		}
 	}
 
 	return &types.SpotifyTrack{
@@ -254,11 +453,12 @@ func buildTrackFromMeta(tags []metaTag, id, url string) *types.SpotifyTrack {
 			Title:      title,
 			Artist:     artist,
 			Album:      album,
+			OGType:     ogType,
 			Duration:   duration,
 			TrackNum:   trackNum,
 			DiscNum:    discNum,
 			CoverURL:   cover,
-			SpotifyURL: url,
+			SpotifyURL: pageURL,
 		},
 		ReleaseDate: release,
 	}

--- a/internal/spotify/spotify_test.go
+++ b/internal/spotify/spotify_test.go
@@ -1,6 +1,7 @@
 package spotify
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -47,6 +48,18 @@ func TestParseSpotifyURL(t *testing.T) {
 			wantID:  "49j6SvuvWfbEKZKzsHCdLJ",
 		},
 		{
+			name:    "www host",
+			url:     "https://www.open.spotify.com/track/49j6SvuvWfbEKZKzsHCdLJ",
+			wantTyp: types.SpotifyEntityTrack,
+			wantID:  "49j6SvuvWfbEKZKzsHCdLJ",
+		},
+		{
+			name:    "host with port",
+			url:     "https://open.spotify.com:443/track/49j6SvuvWfbEKZKzsHCdLJ",
+			wantTyp: types.SpotifyEntityTrack,
+			wantID:  "49j6SvuvWfbEKZKzsHCdLJ",
+		},
+		{
 			name:    "spotify uri",
 			url:     "spotify:track:49j6SvuvWfbEKZKzsHCdLJ",
 			wantTyp: types.SpotifyEntityTrack,
@@ -69,9 +82,9 @@ func TestParseSpotifyURL(t *testing.T) {
 			wantErr: "artist links are not supported",
 		},
 		{
-			name:    "short link rejected",
+			name:    "short link needs resolve",
 			url:     "https://spotify.link/abc123",
-			wantErr: "spotify short links are not supported yet",
+			wantErr: "spotify short links must be resolved before parsing",
 		},
 		{
 			name:    "empty",
@@ -106,7 +119,7 @@ func TestFetchSpotifyTrackLive(t *testing.T) {
 
 	const url = "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC"
 
-	msg := FetchSpotifyTrack(url)
+	msg := FetchSpotifyTrack(context.Background(), url)
 	if msg.Err != "" {
 		t.Fatalf("live fetch failed: %s", msg.Err)
 	}
@@ -149,5 +162,144 @@ func TestParseMetaTagsUnescapesEntities(t *testing.T) {
 	}
 	if tags[0].content != "Foo & Bar 'Baz'" {
 		t.Fatalf("content = %q", tags[0].content)
+	}
+}
+
+func TestParseMetaTagsSingleQuotes(t *testing.T) {
+	htmlBody := `<meta property='og:title' content='Hello World'>`
+	tags := parseMetaTags(htmlBody)
+	if len(tags) != 1 {
+		t.Fatalf("len = %d", len(tags))
+	}
+	if tags[0].property != "og:title" || tags[0].content != "Hello World" {
+		t.Fatalf("got %+v", tags[0])
+	}
+}
+
+func TestParseMetaTagsContentBeforeProperty(t *testing.T) {
+	htmlBody := `<meta content="The Weeknd" name="music:musician_description">`
+	tags := parseMetaTags(htmlBody)
+	if len(tags) != 1 {
+		t.Fatalf("len = %d", len(tags))
+	}
+	if tags[0].property != "music:musician_description" || tags[0].content != "The Weeknd" {
+		t.Fatalf("got %+v", tags[0])
+	}
+}
+
+func TestBuildTrackFromMeta(t *testing.T) {
+	htmlBody := `
+<meta property="og:title" content="Blinding Lights">
+<meta property="og:type" content="music.song">
+<meta property="og:description" content="The Weeknd · After Hours · Song · 2020">
+<meta property="og:image" content="https://i.scdn.co/image/ab67616d0000b2738863bc11d2aa12b54f5aeb36">
+<meta name="music:duration" content="200">
+<meta name="music:album:track" content="9">
+<meta name="music:album:disc" content="1">
+<meta name="music:release_date" content="2020-03-20">
+<meta name="music:musician_description" content="The Weeknd">
+`
+	tags := parseMetaTags(htmlBody)
+	track := buildTrackFromMeta(tags, "0VjIjW4GlUZAMYd2vXMi3b", "https://open.spotify.com/track/0VjIjW4GlUZAMYd2vXMi3b")
+	if track == nil {
+		t.Fatal("expected track")
+	}
+	if track.Title != "Blinding Lights" {
+		t.Errorf("title = %q", track.Title)
+	}
+	if track.Artist != "The Weeknd" {
+		t.Errorf("artist = %q", track.Artist)
+	}
+	if track.Album != "After Hours" {
+		t.Errorf("album = %q", track.Album)
+	}
+	if track.OGType != "music.song" {
+		t.Errorf("ogType = %q", track.OGType)
+	}
+	if track.Duration != 200 {
+		t.Errorf("duration = %v", track.Duration)
+	}
+	if track.TrackNum != 9 || track.DiscNum != 1 {
+		t.Errorf("track/disc = %d/%d", track.TrackNum, track.DiscNum)
+	}
+	if track.ReleaseDate != "2020-03-20" {
+		t.Errorf("release = %q", track.ReleaseDate)
+	}
+	if !strings.Contains(track.CoverURL, "ab67616d0000b273") {
+		t.Errorf("cover = %q", track.CoverURL)
+	}
+}
+
+func TestBuildTrackFromMetaArtistFromDescription(t *testing.T) {
+	htmlBody := `
+<meta property="og:title" content="Song">
+<meta property="og:description" content="Artist Name · Album Name · Song · 2021">
+`
+	tags := parseMetaTags(htmlBody)
+	track := buildTrackFromMeta(tags, "id", "https://open.spotify.com/track/id")
+	if track == nil {
+		t.Fatal("expected track")
+	}
+	if track.Artist != "Artist Name" {
+		t.Errorf("artist = %q", track.Artist)
+	}
+	if track.Album != "Album Name" {
+		t.Errorf("album = %q", track.Album)
+	}
+}
+
+func TestValidateSpotifyTrackPage(t *testing.T) {
+	if err := validateSpotifyTrackPage(`<meta property="og:title" content="x">`); err != nil {
+		t.Fatalf("valid page: %v", err)
+	}
+	if err := validateSpotifyTrackPage(`please complete the captcha`); err == nil || !strings.Contains(err.Error(), "bot challenge") {
+		t.Fatalf("captcha err = %v", err)
+	}
+	if err := validateSpotifyTrackPage(`short`); err == nil || !strings.Contains(err.Error(), "empty or blocked") {
+		t.Fatalf("short page err = %v", err)
+	}
+	longNoMeta := strings.Repeat("x", 600)
+	if err := validateSpotifyTrackPage(longNoMeta); err == nil || !strings.Contains(err.Error(), "missing track metadata") {
+		t.Fatalf("missing meta err = %v", err)
+	}
+}
+
+func TestFetchManagerCancel(t *testing.T) {
+	fm := NewFetchManager()
+	ctx, _ := fm.Begin()
+	if ctx.Err() != nil {
+		t.Fatal("fresh context should be active")
+	}
+	fm.Cancel()
+	if ctx.Err() == nil {
+		t.Fatal("context should be canceled")
+	}
+}
+
+func TestFetchManagerTokenClear(t *testing.T) {
+	fm := NewFetchManager()
+
+	// Active request cancels its own context via an owning Clear.
+	ctxA, tokA := fm.Begin()
+	fm.Clear(tokA)
+	if ctxA.Err() == nil {
+		t.Fatal("owning Clear should cancel the active context")
+	}
+
+	// A new request supersedes the old slot; the old token must be inert
+	// and must not clobber the now-active context.
+	ctxB, tokB := fm.Begin()
+	if tokB == tokA {
+		t.Fatal("tokens must be unique across Begin calls")
+	}
+	fm.Clear(tokA) // stale clear from the superseded request
+	if ctxB.Err() != nil {
+		t.Fatal("stale Clear must not affect the active context")
+	}
+
+	// Only the matching owning Clear cancels the active context.
+	fm.Clear(tokB)
+	if ctxB.Err() == nil {
+		t.Fatal("owning Clear should cancel the active context")
 	}
 }

--- a/internal/spotify/spotify_test.go
+++ b/internal/spotify/spotify_test.go
@@ -1,0 +1,153 @@
+package spotify
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/xdagiz/xytz/internal/types"
+)
+
+func TestParseSpotifyURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantTyp types.SpotifyEntityType
+		wantID  string
+		wantErr string
+	}{
+		{
+			name:    "canonical track",
+			url:     "https://open.spotify.com/track/49j6SvuvWfbEKZKzsHCdLJ",
+			wantTyp: types.SpotifyEntityTrack,
+			wantID:  "49j6SvuvWfbEKZKzsHCdLJ",
+		},
+		{
+			name:    "track with query",
+			url:     "https://open.spotify.com/track/49j6SvuvWfbEKZKzsHCdLJ?si=abc",
+			wantTyp: types.SpotifyEntityTrack,
+			wantID:  "49j6SvuvWfbEKZKzsHCdLJ",
+		},
+		{
+			name:    "intl locale track",
+			url:     "https://open.spotify.com/intl-de/track/49j6SvuvWfbEKZKzsHCdLJ",
+			wantTyp: types.SpotifyEntityTrack,
+			wantID:  "49j6SvuvWfbEKZKzsHCdLJ",
+		},
+		{
+			name:    "embed track",
+			url:     "https://open.spotify.com/embed/track/49j6SvuvWfbEKZKzsHCdLJ",
+			wantTyp: types.SpotifyEntityTrack,
+			wantID:  "49j6SvuvWfbEKZKzsHCdLJ",
+		},
+		{
+			name:    "intl embed track",
+			url:     "https://open.spotify.com/intl-fr/embed/track/49j6SvuvWfbEKZKzsHCdLJ",
+			wantTyp: types.SpotifyEntityTrack,
+			wantID:  "49j6SvuvWfbEKZKzsHCdLJ",
+		},
+		{
+			name:    "spotify uri",
+			url:     "spotify:track:49j6SvuvWfbEKZKzsHCdLJ",
+			wantTyp: types.SpotifyEntityTrack,
+			wantID:  "49j6SvuvWfbEKZKzsHCdLJ",
+		},
+		{
+			name:    "album",
+			url:     "https://open.spotify.com/album/4yP0hdKOZPNshxUOjY0cZj",
+			wantTyp: types.SpotifyEntityAlbum,
+			wantID:  "4yP0hdKOZPNshxUOjY0cZj",
+		},
+		{
+			name:    "artist rejected",
+			url:     "https://open.spotify.com/artist/1Xyo4u8uXC1ZmMpatF05PJ",
+			wantErr: "artist links are not supported",
+		},
+		{
+			name:    "artist uri rejected",
+			url:     "spotify:artist:1Xyo4u8uXC1ZmMpatF05PJ",
+			wantErr: "artist links are not supported",
+		},
+		{
+			name:    "short link rejected",
+			url:     "https://spotify.link/abc123",
+			wantErr: "spotify short links are not supported yet",
+		},
+		{
+			name:    "empty",
+			url:     "",
+			wantErr: "empty url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTyp, gotID, err := ParseSpotifyURL(tt.url)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if gotTyp != tt.wantTyp || gotID != tt.wantID {
+				t.Fatalf("got (%q, %q), want (%q, %q)", gotTyp, gotID, tt.wantTyp, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestFetchSpotifyTrackLive(t *testing.T) {
+	if os.Getenv("XYTZ_LIVE_TESTS") == "" {
+		t.Skip("set XYTZ_LIVE_TESTS=1 to run the live Spotify fetch check")
+	}
+
+	const url = "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC"
+
+	msg := FetchSpotifyTrack(url)
+	if msg.Err != "" {
+		t.Fatalf("live fetch failed: %s", msg.Err)
+	}
+	if msg.Track == nil {
+		t.Fatal("expected track, got nil")
+	}
+	tr := msg.Track
+
+	if tr.ID != "4uLU6hMCjMI75M1A2tKUQC" {
+		t.Errorf("id = %q", tr.ID)
+	}
+	if tr.Title == "" {
+		t.Error("title is empty")
+	}
+	if tr.Artist == "" {
+		t.Error("artist is empty")
+	}
+	if tr.Album == "" {
+		t.Error("album is empty")
+	}
+	if tr.CoverURL == "" || !strings.Contains(tr.CoverURL, "i.scdn.co") {
+		t.Errorf("cover url unexpected: %q", tr.CoverURL)
+	}
+	if tr.Duration <= 0 {
+		t.Errorf("duration = %v, want > 0", tr.Duration)
+	}
+	if tr.ReleaseDate == "" {
+		t.Error("release date is empty")
+	}
+
+	t.Logf("parsed: title=%q artist=%q album=%q release=%q duration=%.0fs cover=%s",
+		tr.Title, tr.Artist, tr.Album, tr.ReleaseDate, tr.Duration, tr.CoverURL)
+}
+
+func TestParseMetaTagsUnescapesEntities(t *testing.T) {
+	htmlBody := `<meta property="og:title" content="Foo &amp; Bar &#39;Baz&#39;">`
+	tags := parseMetaTags(htmlBody)
+	if len(tags) != 1 {
+		t.Fatalf("len = %d", len(tags))
+	}
+	if tags[0].content != "Foo & Bar 'Baz'" {
+		t.Fatalf("content = %q", tags[0].content)
+	}
+}

--- a/internal/tui/context/context.go
+++ b/internal/tui/context/context.go
@@ -7,6 +7,7 @@ import (
 	"github.com/xdagiz/xytz/internal/config"
 	"github.com/xdagiz/xytz/internal/downloader"
 	"github.com/xdagiz/xytz/internal/player"
+	"github.com/xdagiz/xytz/internal/spotify"
 	"github.com/xdagiz/xytz/internal/styles"
 	"github.com/xdagiz/xytz/internal/thumbnail"
 	"github.com/xdagiz/xytz/internal/tui/theme"
@@ -25,14 +26,15 @@ type AppContext struct {
 	Theme  theme.Theme
 	Styles styles.Styles
 
-	LatestVersion string
+	LatestVersion  string
+	VersionFetcher func() (string, error)
 
-	SearchManager    *ytdlp.ExecManager
-	FormatsManager   *ytdlp.ExecManager
-	ThumbnailManager *thumbnail.ThumbnailManager
-	DownloadManager  *downloader.DownloadManager
-	PlayerManager    *player.PlayerManager
-	VersionFetcher   func() (string, error)
+	SearchManager       *ytdlp.ExecManager
+	FormatsManager      *ytdlp.ExecManager
+	ThumbnailManager    *thumbnail.ThumbnailManager
+	DownloadManager     *downloader.DownloadManager
+	PlayerManager       *player.PlayerManager
+	SpotifyFetchManager *spotify.FetchManager
 }
 
 func New(cfg *config.Config, configPath string, runtime config.RuntimeOptions) *AppContext {
@@ -41,15 +43,16 @@ func New(cfg *config.Config, configPath string, runtime config.RuntimeOptions) *
 	}
 
 	c := &AppContext{
-		Config:           cfg,
-		ConfigPath:       configPath,
-		Runtime:          runtime,
-		SearchManager:    ytdlp.NewExecManager(),
-		FormatsManager:   ytdlp.NewExecManager(),
-		ThumbnailManager: thumbnail.NewThumbnailManager(),
-		DownloadManager:  downloader.NewDownloadManager(),
-		PlayerManager:    player.NewPlayerManager(),
-		VersionFetcher:   version.FetchLatestVersion,
+		Config:              cfg,
+		ConfigPath:          configPath,
+		Runtime:             runtime,
+		SearchManager:       ytdlp.NewExecManager(),
+		FormatsManager:      ytdlp.NewExecManager(),
+		ThumbnailManager:    thumbnail.NewThumbnailManager(),
+		DownloadManager:     downloader.NewDownloadManager(),
+		PlayerManager:       player.NewPlayerManager(),
+		SpotifyFetchManager: spotify.NewFetchManager(),
+		VersionFetcher:      version.FetchLatestVersion,
 	}
 
 	c.applyThemeFromConfig()
@@ -93,6 +96,9 @@ func (c *AppContext) CancelManagers() {
 	}
 	if c.DownloadManager != nil {
 		_ = c.DownloadManager.Cancel()
+	}
+	if c.SpotifyFetchManager != nil {
+		c.SpotifyFetchManager.Cancel()
 	}
 	if c.PlayerManager != nil {
 		c.PlayerManager.Kill()

--- a/internal/tui/context/context_test.go
+++ b/internal/tui/context/context_test.go
@@ -31,7 +31,7 @@ func TestNewBuildsReadyContext(t *testing.T) {
 	if c.Theme.TextPrimary == "" {
 		t.Fatalf("theme should be initialized")
 	}
-	if c.SearchManager == nil || c.FormatsManager == nil || c.ThumbnailManager == nil || c.DownloadManager == nil || c.PlayerManager == nil {
+	if c.SearchManager == nil || c.FormatsManager == nil || c.ThumbnailManager == nil || c.DownloadManager == nil || c.PlayerManager == nil || c.SpotifyFetchManager == nil {
 		t.Fatalf("all managers should be initialized")
 	}
 	if c.VersionFetcher == nil {

--- a/internal/tui/models/keys.go
+++ b/internal/tui/models/keys.go
@@ -261,3 +261,11 @@ var PlaylistOptsModelKeys = playlistOptsKeys{
 	Down:        key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
 	ToggleFocus: key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "switch focus")),
 }
+
+type spotifyTrackKeys struct {
+	Download key.Binding
+}
+
+var SpotifyTrackModelKeys = spotifyTrackKeys{
+	Download: key.NewBinding(key.WithKeys("enter", "d"), key.WithHelp("d/enter", "download")),
+}

--- a/internal/tui/models/search/search.go
+++ b/internal/tui/models/search/search.go
@@ -389,17 +389,18 @@ func (m Model) handleEnterKey() (Model, tea.Cmd) {
 	}
 
 	urlType, processedURL := ytdlp.ParseSearchQuery(query)
-	if urlType == "direct" {
-		cmd := func() tea.Msg {
-			return types.StartFormatMsg{URL: processedURL}
-		}
-
-		m.History.AddLocal(query)
-		return m, tea.Batch(cmd, saveHistoryCmd(query))
+	var msg tea.Msg
+	switch urlType {
+	case "spotify":
+		msg = types.StartSpotifyTrackMsg{URL: processedURL}
+	case "direct":
+		msg = types.StartFormatMsg{URL: processedURL}
+	default:
+		msg = types.StartSearchMsg{Query: query, URLType: urlType}
 	}
 
 	cmd := func() tea.Msg {
-		return types.StartSearchMsg{Query: query, URLType: urlType}
+		return msg
 	}
 
 	m.History.AddLocal(query)
@@ -462,6 +463,21 @@ func (m *Model) executeSlashCommand(slashCmd, query, args string) tea.Cmd {
 			m.Autocomplete.Hide()
 			cmd = func() tea.Msg {
 				return types.StartPlaylistsSearchMsg{Query: args}
+			}
+			cmd = tea.Batch(cmd, saveHistoryCmd(query))
+		}
+
+	case "spotify":
+		if args == "" {
+			m.Input.SetValue("/spotify ")
+			m.Input.CursorEnd()
+		} else if strings.Contains(args, " ") {
+			m.ErrMsg = "Spotify url cannot contain spaces"
+		} else {
+			m.History.AddLocal(query)
+			m.Autocomplete.Hide()
+			cmd = func() tea.Msg {
+				return types.StartSpotifyTrackMsg{URL: args}
 			}
 			cmd = tea.Batch(cmd, saveHistoryCmd(query))
 		}

--- a/internal/tui/models/search/slash/commands.go
+++ b/internal/tui/models/search/slash/commands.go
@@ -69,6 +69,12 @@ var AllCommands = []Command{
 		Usage:       "/help",
 		HasArg:      false,
 	},
+	{
+		Name:        "spotify",
+		Description: "Fetch and download a Spotify track",
+		Usage:       "/spotify <url>",
+		HasArg:      true,
+	},
 }
 
 type MatchResult struct {

--- a/internal/tui/models/spotifydownload/spotifydownload.go
+++ b/internal/tui/models/spotifydownload/spotifydownload.go
@@ -1,0 +1,265 @@
+package spotifydownload
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/progress"
+	tea "charm.land/bubbletea/v2"
+	zone "github.com/lrstanley/bubblezone/v2"
+	"github.com/xdagiz/xytz/internal/downloader"
+	appctx "github.com/xdagiz/xytz/internal/tui/context"
+	"github.com/xdagiz/xytz/internal/tui/models"
+	"github.com/xdagiz/xytz/internal/types"
+)
+
+type Model struct {
+	ctx             *appctx.AppContext
+	Progress        progress.Model
+	Track           types.SpotifyTrack
+	CurrentSpeed    string
+	CurrentETA      string
+	Phase           string
+	Completed       bool
+	Paused          bool
+	Cancelled       bool
+	Err             string
+	Destination     string
+	FileDestination string
+	ActiveOpID      string
+	prefix          string
+}
+
+func NewModel(ctx *appctx.AppContext) Model {
+	pr := progress.New(progress.WithColors(ctx.Styles.StatusInfoColor))
+	m := Model{ctx: ctx, Progress: pr, prefix: zone.NewPrefix()}
+	if ctx.Config != nil {
+		m.Destination = ctx.Config.GetSpotifyDownloadPath()
+	}
+	return m
+}
+
+func (m *Model) ApplyTheme() {
+	percent := m.Progress.Percent()
+	width := m.Progress.Width()
+	pr := progress.New(progress.WithColors(m.ctx.Styles.StatusInfoColor))
+	pr.SetWidth(width)
+	_ = pr.SetPercent(percent)
+	m.Progress = pr
+}
+
+func (m *Model) Reset(track types.SpotifyTrack) {
+	m.Track = track
+	m.CurrentSpeed = ""
+	m.CurrentETA = ""
+	m.Phase = ""
+	m.Completed = false
+	m.Paused = false
+	m.Cancelled = false
+	m.Err = ""
+	m.FileDestination = ""
+	m.ActiveOpID = ""
+	_ = m.Progress.SetPercent(0)
+	if m.ctx != nil && m.ctx.Config != nil {
+		m.Destination = m.ctx.Config.GetSpotifyDownloadPath()
+	}
+}
+
+type tickMsg time.Time
+
+func (m Model) Init() tea.Cmd {
+	return tickCmd()
+}
+
+func tickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
+		return tickMsg(t)
+	})
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tickMsg:
+		return m, tickCmd()
+
+	case progress.FrameMsg:
+		m.Progress, cmd = m.Progress.Update(msg)
+		return m, cmd
+
+	case types.ProgressMsg:
+		if m.ActiveOpID != "" && msg.OperationID != m.ActiveOpID {
+			return m, nil
+		}
+		if msg.Percent > 0 {
+			cmd = m.Progress.SetPercent(msg.Percent / 100.0)
+		} else if msg.Percent == 0 && msg.Status != "" && isResetProgressStatus(msg.Status) {
+			cmd = m.Progress.SetPercent(0)
+			m.CurrentSpeed = ""
+			m.CurrentETA = ""
+		}
+		if msg.Speed != "" {
+			m.CurrentSpeed = msg.Speed
+		}
+		if msg.Eta != "" {
+			m.CurrentETA = msg.Eta
+		}
+		if msg.Status != "" {
+			m.Phase = msg.Status
+			if isPostDownloadStatus(msg.Status) {
+				m.CurrentSpeed = ""
+				m.CurrentETA = ""
+			}
+		}
+		if msg.Destination != "" {
+			m.FileDestination = msg.Destination
+		}
+
+	case types.PauseDownloadMsg:
+		m.Paused = true
+
+	case types.ResumeDownloadMsg:
+		m.Paused = false
+
+	case types.CancelDownloadMsg:
+		m.Cancelled = true
+
+	case tea.MouseReleaseMsg:
+		if msg.Button == tea.MouseLeft {
+			if zone.Get(m.prefix + "cancel").InBounds(msg) {
+				cmd = m.cancelDownload()
+			}
+			if zone.Get(m.prefix + "continue").InBounds(msg) {
+				cmd = m.continueCmd()
+			}
+		}
+
+	case tea.KeyPressMsg:
+		if (m.Completed || m.Cancelled || m.Err != "") && msg.Code == tea.KeyEnter {
+			cmd = m.continueCmd()
+		}
+
+		if !m.Completed && !m.Cancelled {
+			switch {
+			case key.Matches(msg, models.DownloadModelKeys.Pause) && downloader.PauseSupported():
+				cmd = m.togglePause()
+			case key.Matches(msg, models.DownloadModelKeys.Cancel):
+				cmd = m.cancelDownload()
+			}
+		}
+	}
+
+	return m, cmd
+}
+
+func (m Model) HandleResize(w, h int) Model {
+	if w > 100 {
+		m.Progress.SetWidth(w/2 - 10)
+	} else {
+		m.Progress.SetWidth(w - 10)
+	}
+	return m
+}
+
+func (m Model) displayDestination() string {
+	if m.FileDestination != "" {
+		return m.FileDestination
+	}
+
+	if m.Track.Title == "" {
+		return m.Destination
+	}
+
+	base := downloader.SanitizeFilename(m.Track.Artist + " - " + m.Track.Title)
+	return filepath.Join(m.Destination, base+".mp3")
+}
+
+func (m Model) View() string {
+	var s strings.Builder
+	if m.Err != "" {
+		s.WriteString(m.ctx.Styles.ErrorMessageStyle.Render(m.Err))
+		s.WriteRune('\n')
+		s.WriteString(zone.Mark(m.prefix+"continue", m.ctx.Styles.HelpStyle.Render("⏎ continue")))
+	}
+
+	if m.Completed {
+		s.WriteString(m.ctx.Styles.CompletionMessageStyle.Render(fmt.Sprintf("✓ %s", m.displayDestination())))
+		s.WriteRune('\n')
+		s.WriteString(zone.Mark(m.prefix+"continue", m.ctx.Styles.HelpStyle.Render("⏎ continue")))
+	}
+
+	if m.Cancelled {
+		s.WriteString(m.ctx.Styles.ErrorMessageStyle.Render("✕ cancelled"))
+	}
+
+	if !m.Completed && !m.Cancelled && m.Err == "" {
+		if m.Paused {
+			s.WriteString(m.ctx.Styles.MutedStyle.Render("Paused"))
+			if m.Progress.Percent() > 0 {
+				s.WriteRune('\n')
+				s.WriteString(m.ctx.Styles.ProgressContainer.Render(m.Progress.View()))
+			}
+		} else if m.isDownloading() {
+			s.WriteString(m.ctx.Styles.ProgressContainer.Render(m.Progress.View()))
+			s.WriteRune('\n')
+			meta := strings.TrimSpace(strings.Trim(m.CurrentSpeed+" · "+m.CurrentETA, " ·"))
+			if meta != "" {
+				s.WriteString(m.ctx.Styles.MutedStyle.Render(meta))
+			}
+		} else {
+			s.WriteString(m.ctx.Styles.MutedStyle.Render(m.displayPhase()))
+		}
+	}
+
+	return s.String()
+}
+
+func (m Model) displayPhase() string {
+	phase := strings.TrimSpace(m.Phase)
+	if phase == "" {
+		return "Preparing…"
+	}
+	return phase
+}
+
+func (m Model) isDownloading() bool {
+	phase := strings.TrimSpace(m.Phase)
+	return strings.HasPrefix(phase, "[download]") && m.Progress.Percent() > 0
+}
+
+func isResetProgressStatus(status string) bool {
+	s := strings.ToLower(strings.TrimSpace(status))
+	return strings.HasPrefix(s, "searching") || strings.HasPrefix(s, "retrying")
+}
+
+func isPostDownloadStatus(status string) bool {
+	s := strings.ToLower(strings.TrimSpace(status))
+	return strings.HasPrefix(s, "fetching cover") ||
+		strings.HasPrefix(s, "processing") ||
+		strings.HasPrefix(s, "[ffmpeg]") ||
+		strings.HasPrefix(s, "[process]")
+}
+
+func (m *Model) togglePause() tea.Cmd {
+	if m.Paused {
+		return downloader.ResumeDownload(m.ctx.DownloadManager)
+	}
+
+	return downloader.PauseDownload(m.ctx.DownloadManager)
+}
+
+func (m *Model) continueCmd() tea.Cmd {
+	return func() tea.Msg {
+		return types.SpotifyDownloadDoneMsg{}
+	}
+}
+
+func (m *Model) cancelDownload() tea.Cmd {
+	return func() tea.Msg {
+		return types.CancelDownloadMsg{}
+	}
+}

--- a/internal/tui/models/spotifydownload/spotifydownload_test.go
+++ b/internal/tui/models/spotifydownload/spotifydownload_test.go
@@ -1,0 +1,100 @@
+package spotifydownload
+
+import (
+	"strings"
+	"testing"
+
+	zone "github.com/lrstanley/bubblezone/v2"
+	"github.com/xdagiz/xytz/internal/config"
+	appctx "github.com/xdagiz/xytz/internal/tui/context"
+	"github.com/xdagiz/xytz/internal/types"
+)
+
+func testCtx(t *testing.T) *appctx.AppContext {
+	t.Helper()
+	zone.NewGlobal()
+	cfg := config.GetDefault()
+	return appctx.New(cfg, "", config.ResolveRuntimeOptions(cfg, nil))
+}
+
+func TestProgressMsgDoesNotClobberPhaseOnEmptyStatus(t *testing.T) {
+	m := NewModel(testCtx(t))
+	m.Phase = "Downloading…"
+	_ = m.Progress.SetPercent(0.8)
+
+	m, _ = m.Update(types.ProgressMsg{
+		Percent:     0,
+		Status:      "",
+		Destination: "/tmp/track.mp3",
+	})
+
+	if m.Phase != "Downloading…" {
+		t.Fatalf("Phase = %q, want preserved Downloading…", m.Phase)
+	}
+	if m.Progress.Percent() < 0.79 {
+		t.Fatalf("progress was reset: %v", m.Progress.Percent())
+	}
+	if m.FileDestination != "/tmp/track.mp3" {
+		t.Fatalf("destination not set: %q", m.FileDestination)
+	}
+}
+
+func TestProgressMsgProcessingStatus(t *testing.T) {
+	m := NewModel(testCtx(t))
+	m.CurrentSpeed = "1MiB/s"
+	m.CurrentETA = "00:10"
+	_ = m.Progress.SetPercent(0.95)
+
+	m, _ = m.Update(types.ProgressMsg{
+		Percent: 100,
+		Status:  "Processing…",
+	})
+
+	if m.Phase != "Processing…" {
+		t.Fatalf("Phase = %q", m.Phase)
+	}
+	if m.CurrentSpeed != "" || m.CurrentETA != "" {
+		t.Fatalf("speed/eta should clear on processing: %q / %q", m.CurrentSpeed, m.CurrentETA)
+	}
+	if m.Progress.Percent() < 0.99 {
+		t.Fatalf("progress = %v, want ~1", m.Progress.Percent())
+	}
+	if got := m.displayPhase(); got != "Processing…" {
+		t.Fatalf("displayPhase = %q", got)
+	}
+}
+
+func TestIsDownloadingAndDisplayPhase(t *testing.T) {
+	m := NewModel(testCtx(t))
+
+	m.Phase = "[download] format 251"
+	_ = m.Progress.SetPercent(0.4)
+	if !m.isDownloading() {
+		t.Fatal("expected isDownloading during transfer")
+	}
+
+	m.Phase = "Processing…"
+	if m.isDownloading() {
+		t.Fatal("processing should not count as downloading")
+	}
+	if got := m.displayPhase(); got != "Processing…" {
+		t.Fatalf("displayPhase = %q", got)
+	}
+
+	m.Phase = ""
+	if got := m.displayPhase(); got != "Preparing…" {
+		t.Fatalf("empty displayPhase = %q", got)
+	}
+}
+
+func TestViewShowsPaused(t *testing.T) {
+	m := NewModel(testCtx(t))
+	m.Phase = "[download]"
+	_ = m.Progress.SetPercent(0.5)
+	m.Paused = true
+
+	view := m.View()
+	if !strings.Contains(view, "Paused") {
+		t.Fatalf("view should include Paused, got %q", view)
+	}
+}

--- a/internal/tui/models/spotifytrack/spotifytrack.go
+++ b/internal/tui/models/spotifytrack/spotifytrack.go
@@ -1,0 +1,60 @@
+package spotifytrack
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	appctx "github.com/xdagiz/xytz/internal/tui/context"
+	"github.com/xdagiz/xytz/internal/types"
+	"github.com/xdagiz/xytz/internal/utils"
+)
+
+type Model struct {
+	ctx    *appctx.AppContext
+	Width  int
+	Height int
+	Track  types.SpotifyTrack
+}
+
+func NewModel(ctx *appctx.AppContext) Model {
+	return Model{ctx: ctx}
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) HandleResize(w, h int) Model {
+	m.Width = w
+	m.Height = h
+	return m
+}
+
+func (m Model) View() string {
+	var s strings.Builder
+
+	s.WriteString(m.ctx.Styles.SectionHeaderStyle.Render("♪ " + m.Track.Title))
+	s.WriteRune('\n')
+
+	if m.Track.Artist != "" {
+		s.WriteString(m.ctx.Styles.MutedStyle.Render("🎙️ " + m.Track.Artist))
+		s.WriteRune('\n')
+	}
+
+	if m.Track.Album != "" {
+		s.WriteString(m.ctx.Styles.MutedStyle.Render("💿 " + m.Track.Album))
+		s.WriteRune('\n')
+	}
+
+	if m.Track.ReleaseDate != "" {
+		s.WriteString(m.ctx.Styles.MutedStyle.Render("🗓  " + m.Track.ReleaseDate))
+		s.WriteRune('\n')
+	}
+
+	if m.Track.Duration > 0 {
+		s.WriteString(m.ctx.Styles.MutedStyle.Render("⏱  " + utils.FormatDuration(m.Track.Duration)))
+		s.WriteRune('\n')
+	}
+
+	return s.String()
+}

--- a/internal/tui/models/spotifytrack/spotifytrack.go
+++ b/internal/tui/models/spotifytrack/spotifytrack.go
@@ -33,6 +33,7 @@ func (m Model) HandleResize(w, h int) Model {
 func (m Model) View() string {
 	var s strings.Builder
 
+	s.WriteRune('\n')
 	s.WriteString(m.ctx.Styles.SectionHeaderStyle.Render("♪ " + m.Track.Title))
 	s.WriteRune('\n')
 

--- a/internal/tui/models/thumbnail/thumbnail.go
+++ b/internal/tui/models/thumbnail/thumbnail.go
@@ -41,6 +41,7 @@ type Model struct {
 	Seq              int
 	Enabled          bool
 	ImageHeight      int
+	square           bool
 	width            int
 	height           int
 	TerminalFeatures *termimg.TerminalFeatures
@@ -99,6 +100,14 @@ func (m *Model) detectKittyOnST(fallback *termimg.TerminalFeatures) *termimg.Ter
 
 	fallback.KittyGraphics = true
 	return fallback
+}
+
+func (m *Model) SetSquare(b bool) {
+	m.square = b
+}
+
+func (m Model) ImageString() string {
+	return m.Rendered
 }
 
 func (m Model) Init() tea.Cmd {
@@ -292,6 +301,11 @@ func (m Model) graphicRenderCmd() tea.Cmd {
 	rendered := m.Rendered
 	col := m.width - m.PaneWidth() + 2
 	row := m.thumbnailRow()
+
+	if m.square {
+		col = 2
+	}
+
 	if col > m.width {
 		col = m.width
 	}
@@ -312,6 +326,9 @@ func (m Model) graphicRenderCmd() tea.Cmd {
 }
 
 func (m Model) thumbnailRow() int {
+	if m.square {
+		return 2
+	}
 	return 3
 }
 
@@ -326,10 +343,51 @@ func (m *Model) configureWidget(w *termimg.ImageWidget) {
 	}
 
 	width := max(paneWidth-4, 8)
-	height := max((width*9)/32, 2)
+	if m.square {
+		maxH := max(m.height/3, 2)
+		maxW := max(m.width-4, 8)
 
+		size := min(maxW, maxH*2)
+		size = max(size, 8)
+
+		w.SetSizeWithCorrection(size, size)
+		m.ImageHeight = size / 2
+
+		return
+	}
+
+	height := max((width*9)/32, 2)
 	m.ImageHeight = height
 	w.SetSize(width, height)
+}
+
+func (m Model) reservedSquareHeight() int {
+	if m.width < 60 {
+		return 0
+	}
+
+	maxH := max(m.height/3, 2)
+	maxW := max(m.width-4, 8)
+	size := min(maxW, maxH*2)
+	size = max(size, 8)
+
+	return size / 2
+}
+
+func (m Model) CoverCells() int {
+	if !m.Enabled {
+		return 0
+	}
+
+	if m.Rendered != "" {
+		return m.ImageHeight
+	}
+
+	if m.ThumbnailErr != "" {
+		return 0
+	}
+
+	return m.reservedSquareHeight()
 }
 
 func (m Model) RefreshRenderCmd() tea.Cmd {

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -12,6 +12,7 @@ import (
 	"github.com/xdagiz/xytz/internal/tui/models/playlistlist"
 	"github.com/xdagiz/xytz/internal/tui/models/playlistopts"
 	"github.com/xdagiz/xytz/internal/tui/models/search"
+	"github.com/xdagiz/xytz/internal/tui/models/spotifydownload"
 	"github.com/xdagiz/xytz/internal/tui/models/spotifytrack"
 	"github.com/xdagiz/xytz/internal/tui/models/thumbnail"
 	"github.com/xdagiz/xytz/internal/tui/models/videolist"
@@ -35,6 +36,7 @@ type Model struct {
 	player          player.Model
 	playlistOpts    playlistopts.Model
 	spotifyTrack    spotifytrack.Model
+	spotifyDownload spotifydownload.Model
 	thumbnail       thumbnail.Model
 	Spinner         spinner.Model
 	State           types.State
@@ -71,19 +73,20 @@ func NewModel(appCtx *ctx.AppContext, opts ...ModelOption) *Model {
 	sp.Style = sp.Style.Foreground(appCtx.Styles.AccentSecondaryColor)
 
 	model := &Model{
-		State:        types.StateSearchInput,
-		Spinner:      sp,
-		Search:       search.NewModel(appCtx),
-		videolist:    videolist.NewModel(appCtx),
-		thumbnail:    thumbnail.NewModel(appCtx),
-		channellist:  channellist.NewModel(appCtx),
-		playlistlist: playlistlist.NewModel(appCtx),
-		formatlist:   formatlist.NewModel(appCtx),
-		download:     download.NewModel(appCtx),
-		player:       player.NewModel(appCtx),
-		playlistOpts: playlistopts.NewModel(appCtx),
-		spotifyTrack: spotifytrack.NewModel(appCtx),
-		Ctx:          appCtx,
+		State:           types.StateSearchInput,
+		Spinner:         sp,
+		Search:          search.NewModel(appCtx),
+		videolist:       videolist.NewModel(appCtx),
+		thumbnail:       thumbnail.NewModel(appCtx),
+		channellist:     channellist.NewModel(appCtx),
+		playlistlist:    playlistlist.NewModel(appCtx),
+		formatlist:      formatlist.NewModel(appCtx),
+		download:        download.NewModel(appCtx),
+		player:          player.NewModel(appCtx),
+		playlistOpts:    playlistopts.NewModel(appCtx),
+		spotifyTrack:    spotifytrack.NewModel(appCtx),
+		spotifyDownload: spotifydownload.NewModel(appCtx),
+		Ctx:             appCtx,
 	}
 
 	for _, opt := range opts {
@@ -94,7 +97,7 @@ func NewModel(appCtx *ctx.AppContext, opts ...ModelOption) *Model {
 }
 
 func (m *Model) Init() tea.Cmd {
-	return tea.Batch(m.Search.Init(), m.download.Init(), m.fetchLatestVersion(), m.initCommandFromOptions())
+	return tea.Batch(m.Search.Init(), m.download.Init(), m.spotifyDownload.Init(), m.fetchLatestVersion(), m.initCommandFromOptions())
 }
 
 func (m *Model) initCommandFromOptions() tea.Cmd {
@@ -171,6 +174,7 @@ func (m *Model) applyThemeToSubmodels() {
 	m.playlistlist.ApplyTheme()
 	m.formatlist.ApplyTheme()
 	m.download.ApplyTheme()
+	m.spotifyDownload.ApplyTheme()
 }
 
 type latestVersionMsg struct {

--- a/internal/tui/ui.go
+++ b/internal/tui/ui.go
@@ -12,6 +12,7 @@ import (
 	"github.com/xdagiz/xytz/internal/tui/models/playlistlist"
 	"github.com/xdagiz/xytz/internal/tui/models/playlistopts"
 	"github.com/xdagiz/xytz/internal/tui/models/search"
+	"github.com/xdagiz/xytz/internal/tui/models/spotifytrack"
 	"github.com/xdagiz/xytz/internal/tui/models/thumbnail"
 	"github.com/xdagiz/xytz/internal/tui/models/videolist"
 	"github.com/xdagiz/xytz/internal/types"
@@ -33,6 +34,7 @@ type Model struct {
 	download        download.Model
 	player          player.Model
 	playlistOpts    playlistopts.Model
+	spotifyTrack    spotifytrack.Model
 	thumbnail       thumbnail.Model
 	Spinner         spinner.Model
 	State           types.State
@@ -80,6 +82,7 @@ func NewModel(appCtx *ctx.AppContext, opts ...ModelOption) *Model {
 		download:     download.NewModel(appCtx),
 		player:       player.NewModel(appCtx),
 		playlistOpts: playlistopts.NewModel(appCtx),
+		spotifyTrack: spotifytrack.NewModel(appCtx),
 		Ctx:          appCtx,
 	}
 

--- a/internal/tui/ui_test.go
+++ b/internal/tui/ui_test.go
@@ -375,12 +375,12 @@ func TestModelInit_QueryOptionSetsLoadingAndCommand(t *testing.T) {
 	if !ok {
 		t.Fatalf("Init cmd() type = %T, want tea.BatchMsg", msg)
 	}
-	// Search.Init, download.Init, fetchLatestVersion, initCommandFromOptions
-	if len(batch) < 4 {
-		t.Fatalf("batch command count = %d, want >= 4", len(batch))
+	// Search.Init, download.Init, spotifyDownload.Init, fetchLatestVersion, initCommandFromOptions
+	if len(batch) < 5 {
+		t.Fatalf("batch command count = %d, want >= 5", len(batch))
 	}
 
-	optionMsg := batch[3]()
+	optionMsg := batch[4]()
 	startFormat, ok := optionMsg.(types.StartFormatMsg)
 	if !ok {
 		t.Fatalf("option cmd msg type = %T, want types.StartFormatMsg for video query", optionMsg)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	log "charm.land/log/v2"
@@ -27,6 +28,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 )
+
+var spotifyOpSeq atomic.Uint64
 
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var (
@@ -55,6 +58,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.playlistlist = m.playlistlist.HandleResize(listWidth, m.Height)
 		m.formatlist = m.formatlist.HandleResize(m.Width, m.Height)
 		m.download = m.download.HandleResize(m.Width, m.Height)
+		m.spotifyDownload = m.spotifyDownload.HandleResize(m.Width, m.Height)
 		m.playlistOpts = m.playlistOpts.HandleResize(m.Width, m.Height)
 		if m.thumbnail.Widget != nil {
 			cmd = tea.Batch(cmd, m.thumbnail.RefreshRenderCmd())
@@ -77,7 +81,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.thumbnail.Seq++
 						cmd = tea.Batch(cmd, m.thumbnail.QueueFetch(m.thumbnail.Seq, playlist.ID, playlist.Thumbnail, m.Search.CookiesFromBrowser, m.Search.Cookies))
 					}
-				case types.StateSpotifyTrack:
+				case types.StateSpotifyTrack, types.StateSpotifyDownload:
 					if m.spotifyTrack.Track.ID != "" {
 						cmd = tea.Batch(cmd, m.queueSpotifyCoverCmd())
 					}
@@ -144,7 +148,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.transitionTo(types.StateLoading)
 		m.LoadingType = "spotify"
 		m.CurrentQuery = msg.URL
-		return m, tea.Batch(spotify.FetchSpotifyTrackCmd(msg.URL), m.Spinner.Tick)
+		cmd = spotify.FetchSpotifyTrackCmd(m.Ctx.SpotifyFetchManager, msg.URL)
+		return m, tea.Batch(cmd, m.Spinner.Tick)
 
 	case types.StartChannelsSearchMsg:
 		if m.Ctx.SearchManager == nil || m.Ctx.Config == nil {
@@ -336,6 +341,24 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmd = downloader.StartDownload(m.Ctx.DownloadManager, m.Ctx.Config, m.Program, req)
 		return m, cmd
 
+	case types.StartSpotifyTrackDownloadMsg:
+		if m.Ctx.DownloadManager == nil || m.Ctx.Config == nil {
+			m.ErrMsg = "Download manager not available"
+			return m, nil
+		}
+		m.spotifyDownload.Reset(msg.Track)
+		m.spotifyDownload.ActiveOpID = fmt.Sprintf("sp-%d", spotifyOpSeq.Add(1))
+		m.spotifyTrack.Track = msg.Track
+		m.transitionTo(types.StateSpotifyDownload)
+		req := types.StartSpotifyTrackDownloadMsg{
+			Track:              msg.Track,
+			CookiesFromBrowser: msg.CookiesFromBrowser,
+			Cookies:            msg.Cookies,
+			OperationID:        m.spotifyDownload.ActiveOpID,
+		}
+		cmd = downloader.StartSpotifyTrackDownload(m.Ctx.DownloadManager, m.Ctx.Config, m.Program, req)
+		return m, tea.Batch(cmd, m.spotifyDownload.Init())
+
 	case types.OpenPlaylistConfirmMsg:
 		m.transitionTo(types.StatePlaylistOpts)
 		m.playlistOpts.Reset()
@@ -483,6 +506,26 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case types.DownloadResultMsg:
 		m.LoadingType = ""
+		if m.State == types.StateSpotifyDownload {
+			if msg.OperationID != m.spotifyDownload.ActiveOpID {
+				return m, nil
+			}
+			if msg.Err != "" {
+				if m.spotifyDownload.Cancelled {
+					return m, nil
+				}
+				m.spotifyDownload.Err = msg.Err
+				return m, nil
+			}
+			m.spotifyDownload.Completed = true
+			if msg.Destination != "" {
+				m.spotifyDownload.FileDestination = msg.Destination
+			}
+			return m, nil
+		}
+		if isSpotifyUIState(m.State) {
+			return m, nil
+		}
 		if m.download.IsQueue {
 			if m.download.QueueIndex > 0 && m.download.QueueIndex <= len(m.download.QueueItems) {
 				item := &m.download.QueueItems[m.download.QueueIndex-1]
@@ -552,15 +595,34 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resetDownloadState()
 		return m, queueCmd
 
+	case types.SpotifyDownloadDoneMsg:
+		return m, m.returnToSpotifyTrack()
+
 	case types.PauseDownloadMsg:
+		if m.State == types.StateSpotifyDownload {
+			m.spotifyDownload.Paused = true
+			return m, nil
+		}
 		m.download.Paused = true
 		return m, nil
 
 	case types.ResumeDownloadMsg:
+		if m.State == types.StateSpotifyDownload {
+			m.spotifyDownload.Paused = false
+			return m, nil
+		}
 		m.download.Paused = false
 		return m, nil
 
 	case types.CancelDownloadMsg:
+		if m.State == types.StateSpotifyDownload {
+			m.spotifyDownload.Cancelled = true
+			if m.Ctx != nil && m.Ctx.DownloadManager != nil {
+				_ = m.Ctx.DownloadManager.Cancel()
+			}
+			return m, m.returnToSpotifyTrack()
+		}
+
 		m.download.Cancelled = true
 		if m.Ctx != nil && m.Ctx.DownloadManager != nil {
 			_ = m.Ctx.DownloadManager.Cancel()
@@ -670,6 +732,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case types.CancelSearchMsg:
 		m.transitionTo(types.StateSearchInput)
 		m.ErrMsg = "Search cancelled"
+		m.clearSelections()
+		return m, nil
+
+	case types.CancelSpotifyFetchMsg:
+		m.transitionTo(types.StateSearchInput)
+		m.ErrMsg = "Fetch cancelled"
 		m.clearSelections()
 		return m, nil
 
@@ -958,6 +1026,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				switch m.LoadingType {
 				case "format", "fetch_info":
 					cmd = ytdlp.CancelFormats(m.Ctx.FormatsManager)
+				case "spotify":
+					cmd = spotify.CancelFetch(m.Ctx.SpotifyFetchManager)
 				case "channels":
 					cmd = ytdlp.CancelSearch(m.Ctx.SearchManager)
 				default:
@@ -1075,9 +1145,29 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case types.StateSpotifyTrack:
 			switch msg.String() {
+			case "d", "enter":
+				return m, func() tea.Msg {
+					return types.StartSpotifyTrackDownloadMsg{
+						Track:              m.spotifyTrack.Track,
+						CookiesFromBrowser: m.Search.CookiesFromBrowser,
+						Cookies:            m.Search.Cookies,
+					}
+				}
 			case "b", "esc":
 				return m, goBackCmd(types.StateSpotifyTrack, types.StateSearchInput)
 			}
+
+		case types.StateSpotifyDownload:
+			if msg.String() == "b" || msg.String() == "esc" {
+				if m.spotifyDownload.Completed || m.spotifyDownload.Cancelled || m.spotifyDownload.Err != "" {
+					return m, m.returnToSpotifyTrack()
+				}
+				return m, func() tea.Msg {
+					return types.CancelDownloadMsg{}
+				}
+			}
+			m.spotifyDownload, cmd = m.spotifyDownload.Update(msg)
+			return m, cmd
 
 		case types.StateVideoPlaying:
 			switch msg.String() {
@@ -1113,6 +1203,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Search.LaterList, cmd = m.Search.LaterList.Update(msg)
 		case types.StateDownload:
 			m.download, cmd = m.download.Update(msg)
+		case types.StateSpotifyDownload:
+			m.spotifyDownload, cmd = m.spotifyDownload.Update(msg)
 		case types.StatePlaylistOpts:
 			m.playlistOpts, cmd = m.playlistOpts.Update(msg)
 		case types.StateVideoPlaying:
@@ -1163,6 +1255,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m.State {
 	case types.StateDownload:
 		m.download, cmd = m.download.Update(msg)
+	case types.StateSpotifyDownload:
+		m.spotifyDownload, cmd = m.spotifyDownload.Update(msg)
 	case types.StateSearchInput:
 		m.Search, cmd = m.Search.Update(msg)
 	case types.StateFormatList:
@@ -1191,15 +1285,22 @@ func (m *Model) currentQueueLabel() string {
 }
 
 func (m *Model) transitionTo(newState types.State) {
-	m.thumbnail.ClearScreen()
-	if m.Ctx != nil && m.Ctx.ThumbnailManager != nil {
-		m.Ctx.ThumbnailManager.Clear()
+	preserveThumb := isSpotifyUIState(m.State) && isSpotifyUIState(newState)
+	if !preserveThumb {
+		m.thumbnail.ClearScreen()
+		if m.Ctx != nil && m.Ctx.ThumbnailManager != nil {
+			m.Ctx.ThumbnailManager.Clear()
+		}
 	}
 
 	m.State = newState
-	m.thumbnail.SetSquare(newState == types.StateSpotifyTrack)
+	m.thumbnail.SetSquare(isSpotifyUIState(newState))
 	m.ErrMsg = ""
 	m.LoadingType = ""
+}
+
+func isSpotifyUIState(s types.State) bool {
+	return s == types.StateSpotifyTrack || s == types.StateSpotifyDownload
 }
 
 func (m *Model) queueSpotifyCoverCmd() tea.Cmd {
@@ -1209,6 +1310,11 @@ func (m *Model) queueSpotifyCoverCmd() tea.Cmd {
 	}
 	m.thumbnail.Seq++
 	return m.thumbnail.QueueFetch(m.thumbnail.Seq, t.ID, t.CoverURL, m.Search.CookiesFromBrowser, m.Search.Cookies)
+}
+
+func (m *Model) returnToSpotifyTrack() tea.Cmd {
+	m.transitionTo(types.StateSpotifyTrack)
+	return m.queueSpotifyCoverCmd()
 }
 
 func (m *Model) setupAndStartQueue(videos []types.VideoItem, formatID string, isAudioTab bool, abr float64, queueLabel string) (tea.Model, tea.Cmd) {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -9,6 +9,7 @@ import (
 	log "charm.land/log/v2"
 	"github.com/xdagiz/xytz/internal/config"
 	"github.com/xdagiz/xytz/internal/downloader"
+	"github.com/xdagiz/xytz/internal/spotify"
 	"github.com/xdagiz/xytz/internal/store"
 	"github.com/xdagiz/xytz/internal/tui/models/channellist"
 	"github.com/xdagiz/xytz/internal/tui/models/download"
@@ -61,6 +62,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.thumbnail.IsGraphicProtocol() || (msg.Width >= 100 && m.thumbnail.Enabled && m.thumbnail.SupportsGraphicProtocol()) {
 			if msg.Width < 100 {
 				m.thumbnail.ClearScreen()
+				if m.State == types.StateSpotifyTrack && m.spotifyTrack.Track.ID != "" {
+					cmd = tea.Batch(cmd, m.queueSpotifyCoverCmd())
+				}
 			} else if m.thumbnail.Enabled && msg.Width >= 100 {
 				switch m.State {
 				case types.StateVideoList:
@@ -72,6 +76,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if playlist, ok := m.playlistlist.SelectedPlaylist(); ok {
 						m.thumbnail.Seq++
 						cmd = tea.Batch(cmd, m.thumbnail.QueueFetch(m.thumbnail.Seq, playlist.ID, playlist.Thumbnail, m.Search.CookiesFromBrowser, m.Search.Cookies))
+					}
+				case types.StateSpotifyTrack:
+					if m.spotifyTrack.Track.ID != "" {
+						cmd = tea.Batch(cmd, m.queueSpotifyCoverCmd())
 					}
 				}
 			}
@@ -131,6 +139,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.videolist.PlaylistURL = ""
 		cmd = ytdlp.PerformSearch(m.Ctx.SearchManager, m.Ctx.Config, msg.Query, m.Search.SortBy.GetSPParam(), m.Search.SearchLimit, m.Search.CookiesFromBrowser, m.Search.Cookies)
 		return m, tea.Batch(cmd, m.Spinner.Tick)
+
+	case types.StartSpotifyTrackMsg:
+		m.transitionTo(types.StateLoading)
+		m.LoadingType = "spotify"
+		m.CurrentQuery = msg.URL
+		return m, tea.Batch(spotify.FetchSpotifyTrackCmd(msg.URL), m.Spinner.Tick)
 
 	case types.StartChannelsSearchMsg:
 		if m.Ctx.SearchManager == nil || m.Ctx.Config == nil {
@@ -196,6 +210,24 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		video, ok := m.videolist.SelectedVideo()
 		m.thumbnail.Seq++
 		return m, m.thumbnail.QueueFromSelection(m.thumbnail.Seq, video, ok, m.Search.CookiesFromBrowser, m.Search.Cookies)
+
+	case types.SpotifyTrackResultMsg:
+		if m.State != types.StateLoading || m.LoadingType != "spotify" {
+			return m, nil
+		}
+		m.LoadingType = ""
+		if msg.Err != "" || msg.Track == nil {
+			m.transitionTo(types.StateSearchInput)
+			if msg.Err != "" {
+				m.ErrMsg = msg.Err
+			} else {
+				m.ErrMsg = "could not load Spotify track"
+			}
+			return m, nil
+		}
+		m.spotifyTrack.Track = *msg.Track
+		m.transitionTo(types.StateSpotifyTrack)
+		return m, m.queueSpotifyCoverCmd()
 
 	case types.ChannelSelectedMsg:
 		if m.Ctx.SearchManager == nil || m.Ctx.Config == nil {
@@ -1041,6 +1073,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.playlistOpts, cmd = m.playlistOpts.Update(msg)
 			return m, cmd
 
+		case types.StateSpotifyTrack:
+			switch msg.String() {
+			case "b", "esc":
+				return m, goBackCmd(types.StateSpotifyTrack, types.StateSearchInput)
+			}
+
 		case types.StateVideoPlaying:
 			switch msg.String() {
 			case "b", "esc":
@@ -1159,8 +1197,18 @@ func (m *Model) transitionTo(newState types.State) {
 	}
 
 	m.State = newState
+	m.thumbnail.SetSquare(newState == types.StateSpotifyTrack)
 	m.ErrMsg = ""
 	m.LoadingType = ""
+}
+
+func (m *Model) queueSpotifyCoverCmd() tea.Cmd {
+	t := m.spotifyTrack.Track
+	if t.ID == "" || t.CoverURL == "" {
+		return nil
+	}
+	m.thumbnail.Seq++
+	return m.thumbnail.QueueFetch(m.thumbnail.Seq, t.ID, t.CoverURL, m.Search.CookiesFromBrowser, m.Search.Cookies)
 }
 
 func (m *Model) setupAndStartQueue(videos []types.VideoItem, formatID string, isAudioTab bool, abr float64, queueLabel string) (tea.Model, tea.Cmd) {
@@ -1254,8 +1302,13 @@ func (m *Model) handleGoBack(from types.State, to types.State) tea.Cmd {
 				m.State = types.StateVideoList
 			} else {
 				m.State = types.StateSearchInput
+				m.ErrMsg = ""
 			}
-			m.ErrMsg = ""
+
+		case types.StateSpotifyTrack:
+			m.Search.Input.SetValue("")
+			m.clearSelections()
+			m.transitionTo(types.StateSearchInput)
 		}
 
 	case types.StateVideoList:

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -152,7 +152,25 @@ func getStatusBarText(m *Model, cfg StatusBarConfig) string {
 		return renderHelp([]key.Binding{
 			binding(keys.Quit),
 			binding(keys.Back),
+			binding(keys.Download),
 		})
+
+	case types.StateSpotifyDownload:
+		if cfg.IsCompleted || cfg.IsCancelled || cfg.HasError {
+			return renderHelp([]key.Binding{
+				binding(keys.Quit),
+				binding(keys.Back),
+				binding(keys.Enter),
+			})
+		}
+		sdKeys := []key.Binding{
+			binding(keys.Quit),
+			binding(keys.Cancel),
+		}
+		if downloader.PauseSupported() {
+			sdKeys = []key.Binding{sdKeys[0], binding(keys.Pause), sdKeys[1]}
+		}
+		return renderHelp(sdKeys)
 
 	default:
 		return renderHelp([]key.Binding{
@@ -195,16 +213,24 @@ func (m *Model) View() tea.View {
 		content = m.playlistOpts.View()
 	case types.StateSpotifyTrack:
 		content = m.spotifyTrackWithThumbnailView()
+	case types.StateSpotifyDownload:
+		content = m.spotifyDownloadWithThumbnailView()
 	case types.StateVideoPlaying:
 		content = m.player.View()
 	}
 
+	isSpotifyDL := m.State == types.StateSpotifyDownload
+	hasError := m.videolist.ErrMsg != ""
+	if isSpotifyDL {
+		hasError = m.spotifyDownload.Err != ""
+	}
+
 	statusCfg := StatusBarConfig{
-		HasError:            m.videolist.ErrMsg != "",
+		HasError:            hasError,
 		HelpVisible:         m.Search.Help.Visible,
-		IsPaused:            m.download.Paused,
-		IsCompleted:         m.download.Completed,
-		IsCancelled:         m.download.Cancelled,
+		IsPaused:            (!isSpotifyDL && m.download.Paused) || (isSpotifyDL && m.spotifyDownload.Paused),
+		IsCompleted:         (!isSpotifyDL && m.download.Completed) || (isSpotifyDL && m.spotifyDownload.Completed),
+		IsCancelled:         (!isSpotifyDL && m.download.Cancelled) || (isSpotifyDL && m.spotifyDownload.Cancelled),
 		SelectedVideosCount: len(m.videolist.SelectedVideos),
 	}
 
@@ -327,6 +353,29 @@ func (m *Model) spotifyTrackWithThumbnailView() string {
 	return info
 }
 
+func (m *Model) spotifyDownloadWithThumbnailView() string {
+	trackInfo := lipgloss.NewStyle().Width(m.Width).Align(lipgloss.Left).Render(m.spotifyTrack.View())
+	dlInfo := lipgloss.NewStyle().Width(m.Width).Align(lipgloss.Left).Render(m.spotifyDownload.View())
+	info := lipgloss.JoinVertical(lipgloss.Top, trackInfo, dlInfo)
+
+	if !m.thumbnail.Enabled || m.Width < 60 {
+		return info
+	}
+
+	cells := m.thumbnail.CoverCells()
+	pending := m.thumbnail.Rendered == "" && m.thumbnail.ThumbnailErr == ""
+	if (m.thumbnail.IsGraphicProtocol() || pending) && cells > 0 {
+		spacer := strings.Join(make([]string, cells), "\n")
+		return lipgloss.JoinVertical(lipgloss.Top, spacer, info)
+	}
+
+	if cover := m.thumbnail.ImageString(); cover != "" {
+		return lipgloss.JoinVertical(lipgloss.Top, cover, info)
+	}
+
+	return info
+}
+
 func (m *Model) playlistListWithThumbnailView() string {
 	if !m.thumbnail.Enabled || m.Width < 100 {
 		return m.playlistlist.View()
@@ -364,6 +413,7 @@ type StatusKeys struct {
 	DownloadDefault key.Binding
 	SelectVideos    key.Binding
 	SelectAll       key.Binding
+	Download        key.Binding
 	DownloadAll     key.Binding
 	CopyURL         key.Binding
 	StarOnGithub    key.Binding
@@ -472,6 +522,13 @@ func GetStatusKeys(state types.State) StatusKeys {
 
 	case types.StateSpotifyTrack:
 		keys.Back = newBackEscBKey()
+		keys.Download = keymodels.SpotifyTrackModelKeys.Download
+
+	case types.StateSpotifyDownload:
+		keys.Back = newBackEscBKey()
+		keys.Pause = keymodels.DownloadModelKeys.Pause
+		keys.Cancel = keymodels.DownloadModelKeys.Cancel
+		keys.Enter = keymodels.DownloadModelKeys.Enter
 
 	case types.StateVideoPlaying:
 		keys.Back = newBackEscBKey()

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -148,6 +148,12 @@ func getStatusBarText(m *Model, cfg StatusBarConfig) string {
 			binding(keys.Back),
 		})
 
+	case types.StateSpotifyTrack:
+		return renderHelp([]key.Binding{
+			binding(keys.Quit),
+			binding(keys.Back),
+		})
+
 	default:
 		return renderHelp([]key.Binding{
 			binding(keys.Quit),
@@ -187,6 +193,8 @@ func (m *Model) View() tea.View {
 		content = m.download.View()
 	case types.StatePlaylistOpts:
 		content = m.playlistOpts.View()
+	case types.StateSpotifyTrack:
+		content = m.spotifyTrackWithThumbnailView()
 	case types.StateVideoPlaying:
 		content = m.player.View()
 	}
@@ -267,6 +275,8 @@ func (m *Model) LoadingView() string {
 			loadingText = fmt.Sprintf("Searching for playlists: %s", m.Ctx.Styles.SpinnerStyle.Render(m.CurrentQuery))
 		case "queue":
 			loadingText = "Starting queue download..."
+		case "spotify":
+			loadingText = fmt.Sprintf("Fetching Spotify track: %s", m.Ctx.Styles.SpinnerStyle.Render(m.CurrentQuery))
 		case "fetch_info":
 			loadingText = fmt.Sprintf("Loading video: %s", m.Ctx.Styles.SpinnerStyle.Render(m.player.URL))
 		}
@@ -293,6 +303,28 @@ func (m *Model) videoListWithThumbnailView() string {
 	}
 
 	return lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+}
+
+func (m *Model) spotifyTrackWithThumbnailView() string {
+	info := lipgloss.NewStyle().Width(m.Width).Align(lipgloss.Left).Render(m.spotifyTrack.View())
+
+	if !m.thumbnail.Enabled || m.Width < 60 {
+		return info
+	}
+
+	cells := m.thumbnail.CoverCells()
+	pending := m.thumbnail.Rendered == "" && m.thumbnail.ThumbnailErr == ""
+
+	if (m.thumbnail.IsGraphicProtocol() || pending) && cells > 0 {
+		spacer := strings.Join(make([]string, cells), "\n")
+		return lipgloss.JoinVertical(lipgloss.Top, spacer, info)
+	}
+
+	if cover := m.thumbnail.ImageString(); cover != "" {
+		return lipgloss.JoinVertical(lipgloss.Top, cover, info)
+	}
+
+	return info
 }
 
 func (m *Model) playlistListWithThumbnailView() string {
@@ -437,6 +469,9 @@ func GetStatusKeys(state types.State) StatusKeys {
 		keys.Pause = keymodels.DownloadModelKeys.Pause
 		keys.Cancel = keymodels.DownloadModelKeys.Cancel
 		keys.CopyURL = keymodels.GlobalModelKeys.CopyURL
+
+	case types.StateSpotifyTrack:
+		keys.Back = newBackEscBKey()
 
 	case types.StateVideoPlaying:
 		keys.Back = newBackEscBKey()

--- a/internal/types/spotify.go
+++ b/internal/types/spotify.go
@@ -13,6 +13,7 @@ type SpotifyTrackItem struct {
 	Title      string
 	Artist     string
 	Album      string
+	OGType     string
 	Duration   float64
 	TrackNum   int
 	DiscNum    int
@@ -34,3 +35,12 @@ type SpotifyTrackResultMsg struct {
 type StartSpotifyTrackMsg struct {
 	URL string
 }
+
+type StartSpotifyTrackDownloadMsg struct {
+	Track              SpotifyTrack
+	CookiesFromBrowser string
+	Cookies            string
+	OperationID        string
+}
+
+type SpotifyDownloadDoneMsg struct{}

--- a/internal/types/spotify.go
+++ b/internal/types/spotify.go
@@ -1,0 +1,36 @@
+package types
+
+type SpotifyEntityType string
+
+const (
+	SpotifyEntityTrack    SpotifyEntityType = "track"
+	SpotifyEntityAlbum    SpotifyEntityType = "album"
+	SpotifyEntityPlaylist SpotifyEntityType = "playlist"
+)
+
+type SpotifyTrackItem struct {
+	ID         string
+	Title      string
+	Artist     string
+	Album      string
+	Duration   float64
+	TrackNum   int
+	DiscNum    int
+	CoverURL   string
+	SpotifyURL string
+}
+
+type SpotifyTrack struct {
+	SpotifyTrackItem
+	ReleaseDate string
+}
+
+type SpotifyTrackResultMsg struct {
+	Type  SpotifyEntityType
+	Track *SpotifyTrack
+	Err   string
+}
+
+type StartSpotifyTrackMsg struct {
+	URL string
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,18 +12,19 @@ const GithubRepoLink = "https://github.com/xdagiz/xytz"
 type State string
 
 const (
-	StateSearchInput  State = "search_input"
-	StateLoading      State = "loading"
-	StateVideoList    State = "video_list"
-	StateChannelList  State = "channel_list"
-	StatePlaylistList State = "playlist_list"
-	StateFormatList   State = "format_list"
-	StateDownload     State = "download"
-	StateResumeList   State = "resume_list"
-	StateLaterList    State = "later_list"
-	StateVideoPlaying State = "video_playing"
-	StatePlaylistOpts State = "playlist_opts"
-	StateSpotifyTrack State = "spotify_track"
+	StateSearchInput     State = "search_input"
+	StateLoading         State = "loading"
+	StateVideoList       State = "video_list"
+	StateChannelList     State = "channel_list"
+	StatePlaylistList    State = "playlist_list"
+	StateFormatList      State = "format_list"
+	StateDownload        State = "download"
+	StateResumeList      State = "resume_list"
+	StateLaterList       State = "later_list"
+	StateVideoPlaying    State = "video_playing"
+	StatePlaylistOpts    State = "playlist_opts"
+	StateSpotifyTrack    State = "spotify_track"
+	StateSpotifyDownload State = "spotify_download"
 )
 
 type StartSearchMsg struct {
@@ -62,6 +63,7 @@ type ProgressMsg struct {
 	QueueIndex    int
 	QueueTotal    int
 	Title         string
+	OperationID   string
 }
 
 type VideoItem struct {
@@ -244,6 +246,7 @@ type DownloadResultMsg struct {
 	Destination string
 	QueueIndex  int
 	QueueTotal  int
+	OperationID string
 }
 
 type DownloadCompleteMsg struct{}
@@ -255,6 +258,8 @@ type ResumeDownloadMsg struct{}
 type CancelDownloadMsg struct{}
 
 type CancelSearchMsg struct{}
+
+type CancelSpotifyFetchMsg struct{}
 
 type CancelFormatsMsg struct{}
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -23,6 +23,7 @@ const (
 	StateLaterList    State = "later_list"
 	StateVideoPlaying State = "video_playing"
 	StatePlaylistOpts State = "playlist_opts"
+	StateSpotifyTrack State = "spotify_track"
 )
 
 type StartSearchMsg struct {

--- a/internal/ytdlp/parse.go
+++ b/internal/ytdlp/parse.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/xdagiz/xytz/internal/spotify"
 	"github.com/xdagiz/xytz/internal/types"
 	"github.com/xdagiz/xytz/internal/utils"
 )
@@ -24,6 +25,13 @@ func ParseSearchQuery(query string) (string, string) {
 	query = strings.TrimSpace(query)
 	if query == "" {
 		return "", ""
+	}
+
+	if spotify.IsSpotifyURL(query) {
+		if strings.HasPrefix(query, "spotify:") {
+			return "spotify", query
+		}
+		return "spotify", NormalizeURL(query)
 	}
 
 	normalizedURL := NormalizeURL(query)

--- a/internal/ytdlp/parse_test.go
+++ b/internal/ytdlp/parse_test.go
@@ -577,6 +577,16 @@ func TestParseSearchQuery(t *testing.T) {
 			query:    "https://example.com/watch?v=abc123",
 			expected: "https://example.com/watch?v=abc123",
 		},
+		{
+			name:     "spotify track URL",
+			query:    "https://open.spotify.com/track/49j6SvuvWfbEKZKzsHCdLJ",
+			expected: "https://open.spotify.com/track/49j6SvuvWfbEKZKzsHCdLJ",
+		},
+		{
+			name:     "spotify uri",
+			query:    "spotify:track:49j6SvuvWfbEKZKzsHCdLJ",
+			expected: "spotify:track:49j6SvuvWfbEKZKzsHCdLJ",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Spotify URL/URI detection, parsing, and safe track fetching with short-link resolution.
  * Added `/spotify <url>` command support for initiating Spotify track fetches from direct inputs.
  * Introduced a Spotify track view and full download workflow (progress, metadata, cover thumbnail, pause/cancel, operation-aware updates).
  * Added `spotify_download_path` setting (default: `~/Music`).
* **Bug Fixes**
  * Improved square thumbnail rendering/layout, including correct reserved-space behavior.
* **Tests**
  * Expanded coverage for Spotify parsing/fetching (including cancellation and optional live tests), TUI states/commands, downloader helpers, and Spotify config defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->