### PR TITLE
fix(player): stable multiple plays without crash

### DIFF
--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -15,7 +15,6 @@ import (
 	"github.com/xdagiz/xytz/internal/tui/models/channellist"
 	"github.com/xdagiz/xytz/internal/tui/models/download"
 	"github.com/xdagiz/xytz/internal/tui/models/formatlist"
-	"github.com/xdagiz/xytz/internal/tui/models/player"
 	"github.com/xdagiz/xytz/internal/tui/models/playlistlist"
 	"github.com/xdagiz/xytz/internal/tui/models/search"
 	"github.com/xdagiz/xytz/internal/tui/models/thumbnail"
@@ -967,7 +966,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.State == types.StateVideoPlaying {
 				m.transitionTo(m.playbackBackTarget())
 			}
-			m.player = player.Model{}
 			m.playbackOrigin = ""
 			return m, nil
 		}


### PR DESCRIPTION
How to reproduce:
1. play any video - works perfectly
2. close the play, then in the same session, play any other video
3. app crashes

This fixes the bug with one 2 changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video playback state handling when the player exits.
  * Preserved the existing player state while returning to the previous playback target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->